### PR TITLE
Sinsemilla hash blind

### DIFF
--- a/halo2_gadgets/src/ecc.rs
+++ b/halo2_gadgets/src/ecc.rs
@@ -205,7 +205,7 @@ impl<C: CurveAffine, EccChip: BaseFitsInScalarInstructions<C>> ScalarVar<C, EccC
 
 /// An integer representing an element of the scalar field for a specific elliptic curve,
 /// for [`FixedPoint`] scalar multiplication.
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub struct ScalarFixed<C: CurveAffine, EccChip: EccInstructions<C>> {
     chip: EccChip,
     inner: EccChip::ScalarFixed,

--- a/halo2_gadgets/src/ecc/chip.rs
+++ b/halo2_gadgets/src/ecc/chip.rs
@@ -49,7 +49,7 @@ impl EccPoint {
     ///
     /// This is an internal API that we only use where we know we have a valid curve point
     /// (specifically inside Sinsemilla).
-    pub(crate) fn from_coordinates_unchecked(
+    pub fn from_coordinates_unchecked(
         x: AssignedCell<Assigned<pallas::Base>, pallas::Base>,
         y: AssignedCell<Assigned<pallas::Base>, pallas::Base>,
     ) -> Self {

--- a/halo2_gadgets/src/sinsemilla.rs
+++ b/halo2_gadgets/src/sinsemilla.rs
@@ -417,7 +417,7 @@ where
     /// [concretesinsemillacommit]: https://zips.z.cash/protocol/nu5.pdf#concretesinsemillacommit
     pub fn hash(
         &self,
-        mut layouter: impl Layouter<C::Base>,
+        layouter: impl Layouter<C::Base>,
         message: Message<C, SinsemillaChip, K, MAX_WORDS>,
     ) -> Result<
         (
@@ -437,7 +437,7 @@ where
     pub fn blind(
         &self,
         mut layouter: impl Layouter<C::Base>,
-        hash: ecc::NonIdentityPoint<C, EccChip>,
+        hash: ecc::Point<C, EccChip>,
         r: ecc::ScalarFixed<C, EccChip>,
     ) -> Result<
         ecc::Point<C, EccChip>,

--- a/halo2_gadgets/src/sinsemilla.rs
+++ b/halo2_gadgets/src/sinsemilla.rs
@@ -464,11 +464,9 @@ where
         ),
         Error,
     > {
-        // TODO: use self.hash and self.blind instead.
         assert_eq!(self.M.sinsemilla_chip, message.chip);
-        let (blind, _) = self.R.mul(layouter.namespace(|| "[r] R"), r)?;
-        let (p, zs) = self.M.hash_to_point(layouter.namespace(|| "M"), message)?;
-        let commitment = p.add(layouter.namespace(|| "M + [r] R"), &blind)?;
+        let (p, zs) = self.hash(layouter.namespace(|| "M"), message)?;
+        let commitment = self.blind(layouter, p.into(), r)?;
         Ok((commitment, zs))
     }
 

--- a/halo2_proofs/src/circuit.rs
+++ b/halo2_proofs/src/circuit.rs
@@ -139,6 +139,16 @@ impl<F: Field> AssignedCell<Assigned<F>, F> {
     }
 }
 
+impl<F: Field> From<AssignedCell<F, F>> for AssignedCell<Assigned<F>, F> {
+    fn from(ac: AssignedCell<F, F>) -> Self {
+        AssignedCell {
+            value: ac.value.map(|a| a.into()),
+            cell: ac.cell,
+            _marker: Default::default()
+        }
+    }
+}
+
 impl<V: Clone, F: Field> AssignedCell<V, F>
 where
     for<'v> Assigned<F>: From<&'v V>,


### PR DESCRIPTION
Support changes for https://github.com/QED-it/orchard/pull/9/files

- Allow MuxChip to work with EccPoint coordinates.
- Separate the commit function into separate hash and blind functions.