### PR TITLE
ecc-mul-short: API for ECC short variable multiplication

### DIFF
--- a/halo2_gadgets/src/ecc.rs
+++ b/halo2_gadgets/src/ecc.rs
@@ -22,6 +22,13 @@ pub trait EccInstructions<C: CurveAffine>:
     /// [`BaseFitsInScalarInstructions`] then this may also be constructed from an element
     /// of the base field.
     type ScalarVar: Clone + Debug;
+    // TODO
+    /// Variable representing a scalar used in variable-base scalar mul.
+    ///
+    /// This type is treated as a full-width scalar. However, if `Self` implements
+    /// [`BaseFitsInScalarInstructions`] then this may also be constructed from an element
+    /// of the base field.
+    type ScalarVarShort: Clone + Debug;
     /// Variable representing a full-width element of the elliptic curve's
     /// scalar field, to be used for fixed-base scalar mul.
     type ScalarFixed: Clone + Debug;
@@ -118,6 +125,15 @@ pub trait EccInstructions<C: CurveAffine>:
         scalar: &Self::ScalarVar,
         base: &Self::NonIdentityPoint,
     ) -> Result<(Self::Point, Self::ScalarVar), Error>;
+
+    // TODO
+    /// Performs variable-base scalar multiplication, returning `[scalar] base`.
+    fn mul_short(
+        &self,
+        layouter: &mut impl Layouter<C::Base>,
+        scalar: &Self::ScalarFixedShort, // TODO: ScalarVarShort instead.
+        base: &Self::NonIdentityPoint,
+    ) -> Result<(Self::Point, Self::ScalarFixedShort), Error>;
 
     /// Performs fixed-base scalar multiplication using a full-width scalar, returning `[scalar] base`.
     fn mul_fixed(
@@ -353,6 +369,31 @@ impl<C: CurveAffine, EccChip: EccInstructions<C>> NonIdentityPoint<C, EccChip> {
                         inner: point,
                     },
                     ScalarVar {
+                        chip: self.chip.clone(),
+                        inner: scalar,
+                    },
+                )
+            })
+    }
+
+    // TODO
+    /// Returns `[by] self`.
+    #[allow(clippy::type_complexity)]
+    pub fn mul_short(
+        &self,
+        mut layouter: impl Layouter<C::Base>,
+        by: ScalarFixedShort<C, EccChip>,
+    ) -> Result<(Point<C, EccChip>, ScalarFixedShort<C, EccChip>), Error> {
+        assert_eq!(self.chip, by.chip);
+        self.chip
+            .mul_short(&mut layouter, &by.inner, &self.inner.clone())
+            .map(|(point, scalar)| {
+                (
+                    Point {
+                        chip: self.chip.clone(),
+                        inner: point,
+                    },
+                    ScalarFixedShort {
                         chip: self.chip.clone(),
                         inner: scalar,
                     },

--- a/halo2_gadgets/src/ecc/chip.rs
+++ b/halo2_gadgets/src/ecc/chip.rs
@@ -407,6 +407,9 @@ pub enum ScalarVar {
     FullWidth,
 }
 
+// TODO
+type EccScalarVarShort = EccScalarFixedShort;
+
 impl<Fixed: FixedPoints<pallas::Affine>> EccInstructions<pallas::Affine> for EccChip<Fixed>
 where
     <Fixed as FixedPoints<pallas::Affine>>::Base:
@@ -419,6 +422,7 @@ where
     type ScalarFixed = EccScalarFixed;
     type ScalarFixedShort = EccScalarFixedShort;
     type ScalarVar = ScalarVar;
+    type ScalarVarShort = EccScalarVarShort; // TODO: use or remove.
     type Point = EccPoint;
     type NonIdentityPoint = NonIdentityEccPoint;
     type X = AssignedCell<pallas::Base, pallas::Base>;
@@ -549,6 +553,23 @@ where
                 todo!()
             }
         }
+    }
+
+    // TODO: consider the sign.
+    // TODO: variant optimized for 64 bits.
+    fn mul_short(
+        &self,
+        layouter: &mut impl Layouter<pallas::Base>,
+        scalar: &Self::ScalarFixedShort, // TODO: ScalarVarShort instead.
+        base: &Self::NonIdentityPoint,
+    ) -> Result<(Self::Point, Self::ScalarFixedShort), Error> {
+        let config = self.config().mul;
+        let (point, scalar2) = config.assign(
+            layouter.namespace(|| "variable-base short scalar mul"),
+            scalar.magnitude.clone(),
+            base,
+        )?;
+        Ok((point, scalar.clone())) // TODO: return scalar2?
     }
 
     fn mul_fixed(

--- a/halo2_gadgets/src/ecc/chip.rs
+++ b/halo2_gadgets/src/ecc/chip.rs
@@ -555,20 +555,24 @@ where
         }
     }
 
-    // TODO: consider the sign.
-    // TODO: variant optimized for 64 bits.
     fn mul_short(
         &self,
         layouter: &mut impl Layouter<pallas::Base>,
         scalar: &Self::ScalarFixedShort, // TODO: ScalarVarShort instead.
         base: &Self::NonIdentityPoint,
     ) -> Result<(Self::Point, Self::ScalarFixedShort), Error> {
-        let config = self.config().mul;
-        let (point, scalar2) = config.assign(
+        let config_mul = self.config().mul;
+        let (point, scalar2) = config_mul.assign(
             layouter.namespace(|| "variable-base short scalar mul"),
             scalar.magnitude.clone(),
             base,
         )?;
+        // TODO: make a variant of "assign" optimized for 64 bits.
+        // TODO: must check the range of the magnitude?
+
+        // TODO: apply the sign, using the gate q_mul_fixed_short in mul_fixed::short::Config
+        let config_short = self.config().mul_fixed_short.clone();
+
         Ok((point, scalar.clone())) // TODO: return scalar2?
     }
 

--- a/halo2_gadgets/src/ecc/chip/mul_fixed/short.rs
+++ b/halo2_gadgets/src/ecc/chip/mul_fixed/short.rs
@@ -265,7 +265,7 @@ impl<Fixed: FixedPoints<pallas::Affine>> Config<Fixed> {
                 region.assign_advice_from_constant(|| "u=0", self.super_config.u, offset, pallas::Base::zero())?;
 
                 // Copy sign to `window` column
-                let sign = scalar.sign.copy_advice(
+                scalar.sign.copy_advice(
                     || "sign",
                     &mut region,
                     self.super_config.window,
@@ -281,7 +281,7 @@ impl<Fixed: FixedPoints<pallas::Affine>> Config<Fixed> {
                 )?;
 
                 // Conditionally negate `y`-coordinate
-                let signed_y_val = sign.value().and_then(|sign| {
+                let signed_y_val = scalar.sign.value().and_then(|sign| {
                     if sign == &-pallas::Base::one() {
                         -point.y.value()
                     } else {

--- a/halo2_gadgets/src/ecc/chip/mul_fixed/short.rs
+++ b/halo2_gadgets/src/ecc/chip/mul_fixed/short.rs
@@ -201,6 +201,8 @@ impl<Fixed: FixedPoints<pallas::Affine>> Config<Fixed> {
             },
         )?;
 
+        // TODO: a function to just apply the sign, using the q_mul_fixed_short gate.
+
         #[cfg(test)]
         // Check that the correct multiple is obtained.
         // This inlined test is only done for valid 64-bit magnitudes


### PR DESCRIPTION
Support for https://github.com/QED-it/orchard/pull/19

Add a function for the ECC multiplication of a variable base by a signed short scalar.