### PR TITLE
 Add variable-base sign-scalar multiplication (upstream)

### DIFF
--- a/halo2_gadgets/src/ecc.rs
+++ b/halo2_gadgets/src/ecc.rs
@@ -4,7 +4,7 @@ use std::fmt::Debug;
 
 use halo2_proofs::{
     arithmetic::CurveAffine,
-    circuit::{Chip, Layouter, Value},
+    circuit::{AssignedCell, Chip, Layouter, Value},
     plonk::Error,
 };
 
@@ -109,6 +109,15 @@ pub trait EccInstructions<C: CurveAffine>:
         layouter: &mut impl Layouter<C::Base>,
         a: &A,
         b: &B,
+    ) -> Result<Self::Point, Error>;
+
+    /// Performs variable-base sign-scalar multiplication, returning `[sign] point`
+    /// `sign` must be in {-1, 1}.
+    fn mul_sign(
+        &self,
+        layouter: &mut impl Layouter<C::Base>,
+        sign: &AssignedCell<C::Base, C::Base>,
+        point: &Self::Point,
     ) -> Result<Self::Point, Error>;
 
     /// Performs variable-base scalar multiplication, returning `[scalar] base`.
@@ -430,6 +439,21 @@ impl<C: CurveAffine, EccChip: EccInstructions<C> + Clone + Debug + Eq> Point<C, 
             .map(|inner| Point {
                 chip: self.chip.clone(),
                 inner,
+            })
+    }
+
+    /// Returns `[sign] self`.
+    /// `sign` must be in {-1, 1}.
+    pub fn mul_sign(
+        &self,
+        mut layouter: impl Layouter<C::Base>,
+        sign: &AssignedCell<C::Base, C::Base>,
+    ) -> Result<Point<C, EccChip>, Error> {
+        self.chip
+            .mul_sign(&mut layouter, sign, &self.inner)
+            .map(|point| Point {
+                chip: self.chip.clone(),
+                inner: point,
             })
     }
 }

--- a/halo2_gadgets/src/ecc.rs
+++ b/halo2_gadgets/src/ecc.rs
@@ -889,6 +889,14 @@ pub(crate) mod tests {
                 )?;
             }
 
+            // Test variable-base sign-scalar multiplication
+            {
+                super::chip::mul_fixed::short::tests::test_mul_sign(
+                    chip.clone(),
+                    layouter.namespace(|| "variable-base sign-scalar mul"),
+                )?;
+            }
+
             // Test full-width fixed-base scalar multiplication
             {
                 super::chip::mul_fixed::full_width::tests::test_mul_fixed(

--- a/halo2_gadgets/src/ecc/chip.rs
+++ b/halo2_gadgets/src/ecc/chip.rs
@@ -532,6 +532,24 @@ where
         )
     }
 
+    /// Performs variable-base sign-scalar multiplication, returning `[sign] point`
+    /// `sign` must be in {-1, 1}.
+    fn mul_sign(
+        &self,
+        layouter: &mut impl Layouter<pallas::Base>,
+        sign: &AssignedCell<pallas::Base, pallas::Base>,
+        point: &Self::Point,
+    ) -> Result<Self::Point, Error> {
+        // Multiply point by sign, using the same gate as mul_fixed::short.
+        // This also constrains sign to be in {-1, 1}.
+        let config_short = self.config().mul_fixed_short.clone();
+        config_short.assign_scalar_sign(
+            layouter.namespace(|| "variable-base sign-scalar mul"),
+            sign,
+            point,
+        )
+    }
+
     fn mul(
         &self,
         layouter: &mut impl Layouter<pallas::Base>,

--- a/halo2_gadgets/src/ecc/chip/mul_fixed/short.rs
+++ b/halo2_gadgets/src/ecc/chip/mul_fixed/short.rs
@@ -307,7 +307,7 @@ impl<Fixed: FixedPoints<pallas::Affine>> Config<Fixed> {
 
 #[cfg(test)]
 pub mod tests {
-    use group::{ff::PrimeField, Curve};
+    use group::{ff::PrimeField, Curve, Group};
     use halo2_proofs::{
         arithmetic::CurveAffine,
         circuit::{AssignedCell, Chip, Layouter, Value},
@@ -724,8 +724,6 @@ pub mod tests {
         chip: EccChip<TestFixedBases>,
         mut layouter: impl Layouter<pallas::Base>,
     ) -> Result<(), Error> {
-        use group::Group;
-
         // Generate a random non-identity point P
         let p_val = pallas::Point::random(rand::rngs::OsRng).to_affine();
         let p = Point::new(
@@ -786,5 +784,152 @@ pub mod tests {
         }
 
         Ok(())
+    }
+
+    #[test]
+    fn invalid_sign_in_mul_sign() {
+        use crate::{ecc::chip::EccConfig, utilities::UtilitiesInstructions};
+        use halo2_proofs::{
+            circuit::{Layouter, SimpleFloorPlanner},
+            dev::{FailureLocation, MockProver, VerifyFailure},
+            plonk::{Circuit, ConstraintSystem, Error},
+        };
+
+        #[derive(Default)]
+        struct MyCircuit {
+            base: Value<pallas::Affine>,
+            sign: Value<pallas::Base>,
+        }
+
+        impl UtilitiesInstructions<pallas::Base> for MyCircuit {
+            type Var = AssignedCell<pallas::Base, pallas::Base>;
+        }
+
+        impl Circuit<pallas::Base> for MyCircuit {
+            type Config = EccConfig<TestFixedBases>;
+            type FloorPlanner = SimpleFloorPlanner;
+
+            fn without_witnesses(&self) -> Self {
+                Self::default()
+            }
+
+            fn configure(meta: &mut ConstraintSystem<pallas::Base>) -> Self::Config {
+                let advices = [
+                    meta.advice_column(),
+                    meta.advice_column(),
+                    meta.advice_column(),
+                    meta.advice_column(),
+                    meta.advice_column(),
+                    meta.advice_column(),
+                    meta.advice_column(),
+                    meta.advice_column(),
+                    meta.advice_column(),
+                    meta.advice_column(),
+                ];
+                let lookup_table = meta.lookup_table_column();
+                let lagrange_coeffs = [
+                    meta.fixed_column(),
+                    meta.fixed_column(),
+                    meta.fixed_column(),
+                    meta.fixed_column(),
+                    meta.fixed_column(),
+                    meta.fixed_column(),
+                    meta.fixed_column(),
+                    meta.fixed_column(),
+                ];
+
+                // Shared fixed column for loading constants
+                let constants = meta.fixed_column();
+                meta.enable_constant(constants);
+
+                let range_check = LookupRangeCheckConfig::configure(meta, advices[9], lookup_table);
+                EccChip::<TestFixedBases>::configure(meta, advices, lagrange_coeffs, range_check)
+            }
+
+            fn synthesize(
+                &self,
+                config: Self::Config,
+                mut layouter: impl Layouter<pallas::Base>,
+            ) -> Result<(), Error> {
+                let chip = EccChip::construct(config.clone());
+
+                let column = config.advices[0];
+
+                //let short_config = config.mul_fixed_short.clone();
+                let base = Point::new(chip.clone(), layouter.namespace(|| "load base"), self.base)?;
+
+                let sign =
+                    self.load_private(layouter.namespace(|| "load sign"), column, self.sign)?;
+
+                base.mul_sign(layouter.namespace(|| "[sign] base"), &sign)?;
+
+                Ok(())
+            }
+        }
+
+        // Copied from halo2_proofs::dev::util
+        fn format_value(v: pallas::Base) -> String {
+            use ff::Field;
+            if v.is_zero_vartime() {
+                "0".into()
+            } else if v == pallas::Base::one() {
+                "1".into()
+            } else if v == -pallas::Base::one() {
+                "-1".into()
+            } else {
+                // Format value as hex.
+                let s = format!("{:?}", v);
+                // Remove leading zeroes.
+                let s = s.strip_prefix("0x").unwrap();
+                let s = s.trim_start_matches('0');
+                format!("0x{}", s)
+            }
+        }
+
+        // Sign that is not +/- 1 should fail
+        // Generate a random non-identity point
+        let point = pallas::Point::random(rand::rngs::OsRng);
+        let circuit = MyCircuit {
+            base: Value::known(point.to_affine()),
+            sign: Value::known(pallas::Base::zero()),
+        };
+
+        let prover = MockProver::<pallas::Base>::run(11, &circuit, vec![]).unwrap();
+        assert_eq!(
+            prover.verify(),
+            Err(vec![
+                VerifyFailure::ConstraintNotSatisfied {
+                    constraint: ((17, "Short fixed-base mul gate").into(), 1, "sign_check").into(),
+                    location: FailureLocation::InRegion {
+                        region: (2, "Signed point").into(),
+                        offset: 0,
+                    },
+                    cell_values: vec![(((Any::Advice, 4).into(), 0).into(), "0".to_string())],
+                },
+                VerifyFailure::ConstraintNotSatisfied {
+                    constraint: (
+                        (17, "Short fixed-base mul gate").into(),
+                        3,
+                        "negation_check"
+                    )
+                        .into(),
+                    location: FailureLocation::InRegion {
+                        region: (2, "Signed point").into(),
+                        offset: 0,
+                    },
+                    cell_values: vec![
+                        (
+                            ((Any::Advice, 1).into(), 0).into(),
+                            format_value(*point.to_affine().coordinates().unwrap().y()),
+                        ),
+                        (
+                            ((Any::Advice, 3).into(), 0).into(),
+                            format_value(*point.to_affine().coordinates().unwrap().y()),
+                        ),
+                        (((Any::Advice, 4).into(), 0).into(), "0".to_string()),
+                    ],
+                }
+            ])
+        );
     }
 }

--- a/halo2_gadgets/src/ecc/chip/mul_fixed/short.rs
+++ b/halo2_gadgets/src/ecc/chip/mul_fixed/short.rs
@@ -856,7 +856,7 @@ pub mod tests {
                 let column = config.advices[0];
 
                 //let short_config = config.mul_fixed_short.clone();
-                let base = Point::new(chip.clone(), layouter.namespace(|| "load base"), self.base)?;
+                let base = Point::new(chip, layouter.namespace(|| "load base"), self.base)?;
 
                 let sign =
                     self.load_private(layouter.namespace(|| "load sign"), column, self.sign)?;


### PR DESCRIPTION
Added a variable-base sign-scalar multiplication called `mul_sign`.
This multiplication inputs a scalar and a base and returns `[scalar]base`.
The scalar must be in {-1, 1}.

To evaluate this multiplication, we re-use the `q_mul_fixed_short` gate.
This gate is used in the fixed-base short signed scalar multiplication to apply the sign of the scalar on the result of `[magnitude]base`.