### PR TITLE
Add some Sinsemilla functionalities

### DIFF
--- a/halo2_gadgets/src/sinsemilla/primitives/addition.rs
+++ b/halo2_gadgets/src/sinsemilla/primitives/addition.rs
@@ -8,7 +8,7 @@ use subtle::{ConstantTimeEq, CtOption};
 ///
 /// Simulated incomplete addition built over complete addition.
 #[derive(Clone, Copy, Debug)]
-pub(super) struct IncompletePoint(CtOption<pallas::Point>);
+pub struct IncompletePoint(CtOption<pallas::Point>);
 
 impl From<pallas::Point> for IncompletePoint {
     fn from(p: pallas::Point) -> Self {


### PR DESCRIPTION
It is now possible to evaluate the Sinsemilla Hash and the blinding factor separately.

These both functionalities are required to be able to evaluate the note commitment in constant time.
