### PR TITLE
Add functionalities for ZSA note commitment

### DIFF
--- a/halo2_gadgets/src/ecc/chip.rs
+++ b/halo2_gadgets/src/ecc/chip.rs
@@ -49,7 +49,7 @@ impl EccPoint {
     ///
     /// This is an internal API that we only use where we know we have a valid curve point
     /// (specifically inside Sinsemilla).
-    pub(crate) fn from_coordinates_unchecked(
+    pub fn from_coordinates_unchecked(
         x: AssignedCell<Assigned<pallas::Base>, pallas::Base>,
         y: AssignedCell<Assigned<pallas::Base>, pallas::Base>,
     ) -> Self {

--- a/halo2_gadgets/src/sinsemilla.rs
+++ b/halo2_gadgets/src/sinsemilla.rs
@@ -415,6 +415,41 @@ where
     /// $\mathsf{SinsemillaCommit}$ from [§ 5.4.8.4][concretesinsemillacommit].
     ///
     /// [concretesinsemillacommit]: https://zips.z.cash/protocol/nu5.pdf#concretesinsemillacommit
+    pub fn hash(
+        &self,
+        layouter: impl Layouter<C::Base>,
+        message: Message<C, SinsemillaChip, K, MAX_WORDS>,
+    ) -> Result<
+        (
+            ecc::NonIdentityPoint<C, EccChip>,
+            Vec<SinsemillaChip::RunningSum>,
+        ),
+        Error,
+    > {
+        assert_eq!(self.M.sinsemilla_chip, message.chip);
+        self.M.hash_to_point(layouter, message)
+    }
+
+    #[allow(clippy::type_complexity)]
+    /// $\mathsf{SinsemillaCommit}$ from [§ 5.4.8.4][concretesinsemillacommit].
+    ///
+    /// [concretesinsemillacommit]: https://zips.z.cash/protocol/nu5.pdf#concretesinsemillacommit
+    pub fn blinding_factor(
+        &self,
+        mut layouter: impl Layouter<C::Base>,
+        r: ecc::ScalarFixed<C, EccChip>,
+    ) -> Result<
+        ecc::Point<C, EccChip>,
+        Error,
+    > {
+        let (blind, _) = self.R.mul(layouter.namespace(|| "[r] R"), r)?;
+        Ok(blind)
+    }
+
+    #[allow(clippy::type_complexity)]
+    /// $\mathsf{SinsemillaCommit}$ from [§ 5.4.8.4][concretesinsemillacommit].
+    ///
+    /// [concretesinsemillacommit]: https://zips.z.cash/protocol/nu5.pdf#concretesinsemillacommit
     pub fn commit(
         &self,
         mut layouter: impl Layouter<C::Base>,
@@ -428,8 +463,8 @@ where
         Error,
     > {
         assert_eq!(self.M.sinsemilla_chip, message.chip);
-        let (blind, _) = self.R.mul(layouter.namespace(|| "[r] R"), r)?;
-        let (p, zs) = self.M.hash_to_point(layouter.namespace(|| "M"), message)?;
+        let blind = self.blinding_factor(layouter.namespace(|| "[r] R"), r)?;
+        let (p, zs) = self.hash(layouter.namespace(|| "M"), message)?;
         let commitment = p.add(layouter.namespace(|| "M + [r] R"), &blind)?;
         Ok((commitment, zs))
     }

--- a/halo2_proofs/src/circuit.rs
+++ b/halo2_proofs/src/circuit.rs
@@ -139,13 +139,12 @@ impl<F: Field> AssignedCell<Assigned<F>, F> {
     }
 }
 
-
 impl<F: Field> From<AssignedCell<F, F>> for AssignedCell<Assigned<F>, F> {
     fn from(ac: AssignedCell<F, F>) -> Self {
         AssignedCell {
             value: ac.value.map(|a| a.into()),
             cell: ac.cell,
-            _marker: Default::default()
+            _marker: Default::default(),
         }
     }
 }

--- a/halo2_proofs/src/circuit.rs
+++ b/halo2_proofs/src/circuit.rs
@@ -139,6 +139,17 @@ impl<F: Field> AssignedCell<Assigned<F>, F> {
     }
 }
 
+
+impl<F: Field> From<AssignedCell<F, F>> for AssignedCell<Assigned<F>, F> {
+    fn from(ac: AssignedCell<F, F>) -> Self {
+        AssignedCell {
+            value: ac.value.map(|a| a.into()),
+            cell: ac.cell,
+            _marker: Default::default()
+        }
+    }
+}
+
 impl<V: Clone, F: Field> AssignedCell<V, F>
 where
     for<'v> Assigned<F>: From<&'v V>,


### PR DESCRIPTION
The following modifications are required to implement the ZSA note commitment in the circuit:
- Added `hash` and `blinding_factor` functions  to be able to evaluate separately the hash and the blinding factor of a commitment
- Exposed `from_coordinates_unchecked` publicly
- Added a function to convert a `AssignedCell<F, F>` into a `AssignedCell<Assigned<F>, F>`

The last two items will be used in our MUX chip.

