### PR TITLE
Simplify ZSA features

### DIFF
--- a/halo2_gadgets/CHANGELOG.md
+++ b/halo2_gadgets/CHANGELOG.md
@@ -12,10 +12,16 @@ and this project adheres to Rust's notion of
   a shorthand for `LookupRangeCheck` specialized with `pallas::Base` and `sinsemilla::K`
 - `halo2_gadgets::utilities::lookup_range_check::PallasLookupRangeCheckConfig` which is
   a shorthand for `LookupRangeCheckConfig` specialized with `pallas::Base` and `sinsemilla::K`
+- `halo2_gadgets::ecc::Point::{mul_sign, new_from_constant}`
+- `halo2_gadgets::sinsemilla::CommitDomain::{blinding_factor, hash_with_private_init, q_init}`
+- `halo2_gadgets::utilities::cond_swap::CondSwapChip::{mux_on_points, mux_on_non_identity_points}`
 
 ### Changed
 - `halo2_gadgets::utilities::lookup_range_check::witness_short` now takes a generic `Lookup`
   instead of directly taking a `LookupRangeCheckConfig<F, K>` reference
+- `halo2_gadgets::sinsemilla::merkle::chip::MerkleConfig::cond_swap_config` is now public
+- `halo2_gadgets::sinsemilla::chip::SinsemillaChip::configure` has a new input
+  `init_from_private_point` to enable the evaluation of Sinsemilla hash from a private point.
 
 ## [0.3.1] - 2024-12-16
 - `halo2_gadgets::poseidon::primitives` is now a re-export of the new `halo2_poseidon`

--- a/halo2_gadgets/src/ecc.rs
+++ b/halo2_gadgets/src/ecc.rs
@@ -773,12 +773,12 @@ pub(crate) mod tests {
         type Base = BaseField;
     }
 
-    struct EccCircuit<Lookup: PallasLookupRangeCheck> {
+    struct MyEccCircuit<Lookup: PallasLookupRangeCheck> {
         test_errors: bool,
         _lookup_marker: PhantomData<Lookup>,
     }
 
-    impl<Lookup: PallasLookupRangeCheck> EccCircuit<Lookup> {
+    impl<Lookup: PallasLookupRangeCheck> MyEccCircuit<Lookup> {
         fn new(test_errors: bool) -> Self {
             Self {
                 test_errors,
@@ -788,12 +788,12 @@ pub(crate) mod tests {
     }
 
     #[allow(non_snake_case)]
-    impl<Lookup: PallasLookupRangeCheck> Circuit<pallas::Base> for EccCircuit<Lookup> {
+    impl<Lookup: PallasLookupRangeCheck> Circuit<pallas::Base> for MyEccCircuit<Lookup> {
         type Config = EccConfig<TestFixedBases, Lookup>;
         type FloorPlanner = SimpleFloorPlanner;
 
         fn without_witnesses(&self) -> Self {
-            EccCircuit::new(false)
+            MyEccCircuit::new(false)
         }
 
         fn configure(meta: &mut ConstraintSystem<pallas::Base>) -> Self::Config {
@@ -969,14 +969,14 @@ pub(crate) mod tests {
     #[test]
     fn ecc_chip() {
         let k = 13;
-        let circuit = EccCircuit::<PallasLookupRangeCheckConfig>::new(true);
+        let circuit = MyEccCircuit::<PallasLookupRangeCheckConfig>::new(true);
         let prover = MockProver::run(k, &circuit, vec![]).unwrap();
         assert_eq!(prover.verify(), Ok(()))
     }
 
     #[test]
     fn test_ecc_chip_against_stored_circuit() {
-        let circuit = EccCircuit::<PallasLookupRangeCheckConfig>::new(false);
+        let circuit = MyEccCircuit::<PallasLookupRangeCheckConfig>::new(false);
         test_against_stored_circuit(circuit, "ecc_chip", 3872);
     }
 
@@ -989,7 +989,7 @@ pub(crate) mod tests {
         root.fill(&WHITE).unwrap();
         let root = root.titled("Ecc Chip Layout", ("sans-serif", 60)).unwrap();
 
-        let circuit = EccCircuit::<PallasLookupRangeCheckConfig>::new(false);
+        let circuit = MyEccCircuit::<PallasLookupRangeCheckConfig>::new(false);
         halo2_proofs::dev::CircuitLayout::default()
             .render(13, &circuit, &root)
             .unwrap();
@@ -998,7 +998,7 @@ pub(crate) mod tests {
     #[test]
     fn ecc_chip_4_5b() {
         let k = 13;
-        let circuit = EccCircuit::<PallasLookupRangeCheck4_5BConfig>::new(true);
+        let circuit = MyEccCircuit::<PallasLookupRangeCheck4_5BConfig>::new(true);
         let prover = MockProver::run(k, &circuit, vec![]).unwrap();
 
         assert_eq!(prover.verify(), Ok(()))
@@ -1006,7 +1006,7 @@ pub(crate) mod tests {
 
     #[test]
     fn test_against_stored_ecc_chip_4_5b() {
-        let circuit = EccCircuit::<PallasLookupRangeCheck4_5BConfig>::new(false);
+        let circuit = MyEccCircuit::<PallasLookupRangeCheck4_5BConfig>::new(false);
         test_against_stored_circuit(circuit, "ecc_chip_4_5b", 3968);
     }
 
@@ -1019,7 +1019,7 @@ pub(crate) mod tests {
         root.fill(&WHITE).unwrap();
         let root = root.titled("Ecc Chip Layout", ("sans-serif", 60)).unwrap();
 
-        let circuit = EccCircuit::<PallasLookupRangeCheck4_5BConfig>::new(false);
+        let circuit = MyEccCircuit::<PallasLookupRangeCheck4_5BConfig>::new(false);
         halo2_proofs::dev::CircuitLayout::default()
             .render(13, &circuit, &root)
             .unwrap();

--- a/halo2_gadgets/src/ecc.rs
+++ b/halo2_gadgets/src/ecc.rs
@@ -842,7 +842,9 @@ pub(crate) mod tests {
 
             // Load 10-bit lookup table. In the Action circuit, this will be
             // provided by the Sinsemilla chip.
-            config.lookup_config.load(&mut layouter)?;
+            config
+                .lookup_config
+                .load_only_range_check_table(&mut layouter)?;
 
             // Generate a random non-identity point P
             let p_val = pallas::Point::random(rand::rngs::OsRng).to_affine(); // P

--- a/halo2_gadgets/src/ecc.rs
+++ b/halo2_gadgets/src/ecc.rs
@@ -842,9 +842,7 @@ pub(crate) mod tests {
 
             // Load 10-bit lookup table. In the Action circuit, this will be
             // provided by the Sinsemilla chip.
-            config
-                .lookup_config
-                .load_only_range_check_table(&mut layouter)?;
+            config.lookup_config.load_range_check_table(&mut layouter)?;
 
             // Generate a random non-identity point P
             let p_val = pallas::Point::random(rand::rngs::OsRng).to_affine(); // P

--- a/halo2_gadgets/src/ecc.rs
+++ b/halo2_gadgets/src/ecc.rs
@@ -625,6 +625,14 @@ pub(crate) mod tests {
     use group::{prime::PrimeCurveAffine, Curve, Group};
     use std::marker::PhantomData;
 
+    use halo2_proofs::{
+        circuit::{Layouter, SimpleFloorPlanner, Value},
+        dev::MockProver,
+        plonk::{Circuit, ConstraintSystem, Error},
+    };
+    use lazy_static::lazy_static;
+    use pasta_curves::pallas;
+
     use super::{
         chip::{
             find_zs_and_us, BaseFieldElem, EccChip, EccConfig, FixedPoint, FullScalar, ShortScalar,
@@ -638,13 +646,6 @@ pub(crate) mod tests {
             PallasLookupRangeCheck, PallasLookupRangeCheck4_5BConfig, PallasLookupRangeCheckConfig,
         },
     };
-    use halo2_proofs::{
-        circuit::{Layouter, SimpleFloorPlanner, Value},
-        dev::MockProver,
-        plonk::{Circuit, ConstraintSystem, Error},
-    };
-    use lazy_static::lazy_static;
-    use pasta_curves::pallas;
 
     #[derive(Debug, Eq, PartialEq, Clone)]
     pub(crate) struct TestFixedBases;

--- a/halo2_gadgets/src/ecc/chip/mul_fixed/short.rs
+++ b/halo2_gadgets/src/ecc/chip/mul_fixed/short.rs
@@ -471,7 +471,7 @@ pub mod tests {
     }
 
     #[derive(Default)]
-    struct MagnitudeSignCircuit<Lookup: PallasLookupRangeCheck> {
+    struct MyMagnitudeSignCircuit<Lookup: PallasLookupRangeCheck> {
         magnitude: Value<pallas::Base>,
         sign: Value<pallas::Base>,
         // For test checking
@@ -480,17 +480,17 @@ pub mod tests {
     }
 
     impl<Lookup: PallasLookupRangeCheck> UtilitiesInstructions<pallas::Base>
-        for MagnitudeSignCircuit<Lookup>
+        for MyMagnitudeSignCircuit<Lookup>
     {
         type Var = AssignedCell<pallas::Base, pallas::Base>;
     }
 
-    impl<Lookup: PallasLookupRangeCheck> Circuit<pallas::Base> for MagnitudeSignCircuit<Lookup> {
+    impl<Lookup: PallasLookupRangeCheck> Circuit<pallas::Base> for MyMagnitudeSignCircuit<Lookup> {
         type Config = EccConfig<TestFixedBases, Lookup>;
         type FloorPlanner = SimpleFloorPlanner;
 
         fn without_witnesses(&self) -> Self {
-            MagnitudeSignCircuit {
+            MyMagnitudeSignCircuit {
                 magnitude: Value::unknown(),
                 sign: Value::unknown(),
                 magnitude_error: Value::unknown(),
@@ -584,41 +584,41 @@ pub mod tests {
         }
     }
 
-    impl<Lookup: PallasLookupRangeCheck> MagnitudeSignCircuit<Lookup> {
+    impl<Lookup: PallasLookupRangeCheck> MyMagnitudeSignCircuit<Lookup> {
         fn test_invalid_magnitude_sign() {
             // Magnitude larger than 64 bits should fail
             {
                 let circuits = [
                     // 2^64
-                    MagnitudeSignCircuit::<Lookup> {
+                    MyMagnitudeSignCircuit::<Lookup> {
                         magnitude: Value::known(pallas::Base::from_u128(1 << 64)),
                         sign: Value::known(pallas::Base::one()),
                         magnitude_error: Value::known(pallas::Base::from(1 << 1)),
                         _lookup_marker: PhantomData,
                     },
                     // -2^64
-                    MagnitudeSignCircuit::<Lookup> {
+                    MyMagnitudeSignCircuit::<Lookup> {
                         magnitude: Value::known(pallas::Base::from_u128(1 << 64)),
                         sign: Value::known(-pallas::Base::one()),
                         magnitude_error: Value::known(pallas::Base::from(1 << 1)),
                         _lookup_marker: PhantomData,
                     },
                     // 2^66
-                    MagnitudeSignCircuit::<Lookup> {
+                    MyMagnitudeSignCircuit::<Lookup> {
                         magnitude: Value::known(pallas::Base::from_u128(1 << 66)),
                         sign: Value::known(pallas::Base::one()),
                         magnitude_error: Value::known(pallas::Base::from(1 << 3)),
                         _lookup_marker: PhantomData,
                     },
                     // -2^66
-                    MagnitudeSignCircuit::<Lookup> {
+                    MyMagnitudeSignCircuit::<Lookup> {
                         magnitude: Value::known(pallas::Base::from_u128(1 << 66)),
                         sign: Value::known(-pallas::Base::one()),
                         magnitude_error: Value::known(pallas::Base::from(1 << 3)),
                         _lookup_marker: PhantomData,
                     },
                     // 2^254
-                    MagnitudeSignCircuit::<Lookup> {
+                    MyMagnitudeSignCircuit::<Lookup> {
                         magnitude: Value::known(pallas::Base::from_u128(1 << 127).square()),
                         sign: Value::known(pallas::Base::one()),
                         magnitude_error: Value::known(
@@ -627,7 +627,7 @@ pub mod tests {
                         _lookup_marker: PhantomData,
                     },
                     // -2^254
-                    MagnitudeSignCircuit::<Lookup> {
+                    MyMagnitudeSignCircuit::<Lookup> {
                         magnitude: Value::known(pallas::Base::from_u128(1 << 127).square()),
                         sign: Value::known(-pallas::Base::one()),
                         magnitude_error: Value::known(
@@ -682,7 +682,7 @@ pub mod tests {
             // Sign that is not +/- 1 should fail
             {
                 let magnitude_u64 = rand::random::<u64>();
-                let circuit: MagnitudeSignCircuit<Lookup> = MagnitudeSignCircuit {
+                let circuit: MyMagnitudeSignCircuit<Lookup> = MyMagnitudeSignCircuit {
                     magnitude: Value::known(pallas::Base::from(magnitude_u64)),
                     sign: Value::known(pallas::Base::zero()),
                     magnitude_error: Value::unknown(),
@@ -744,12 +744,12 @@ pub mod tests {
 
     #[test]
     fn invalid_magnitude_sign() {
-        MagnitudeSignCircuit::<PallasLookupRangeCheckConfig>::test_invalid_magnitude_sign();
+        MyMagnitudeSignCircuit::<PallasLookupRangeCheckConfig>::test_invalid_magnitude_sign();
     }
 
     #[test]
     fn invalid_magnitude_sign_4_5b() {
-        MagnitudeSignCircuit::<PallasLookupRangeCheck4_5BConfig>::test_invalid_magnitude_sign();
+        MyMagnitudeSignCircuit::<PallasLookupRangeCheck4_5BConfig>::test_invalid_magnitude_sign();
     }
 
     pub(crate) fn test_mul_sign<Lookup: PallasLookupRangeCheck>(
@@ -819,24 +819,24 @@ pub mod tests {
     }
 
     #[derive(Default)]
-    struct MulSignCircuit<Lookup: PallasLookupRangeCheck> {
+    struct MyMulSignCircuit<Lookup: PallasLookupRangeCheck> {
         base: Value<pallas::Affine>,
         sign: Value<pallas::Base>,
         _lookup_marker: PhantomData<Lookup>,
     }
 
     impl<Lookup: PallasLookupRangeCheck> UtilitiesInstructions<pallas::Base>
-        for MulSignCircuit<Lookup>
+        for MyMulSignCircuit<Lookup>
     {
         type Var = AssignedCell<pallas::Base, pallas::Base>;
     }
 
-    impl<Lookup: PallasLookupRangeCheck> Circuit<pallas::Base> for MulSignCircuit<Lookup> {
+    impl<Lookup: PallasLookupRangeCheck> Circuit<pallas::Base> for MyMulSignCircuit<Lookup> {
         type Config = EccConfig<TestFixedBases, Lookup>;
         type FloorPlanner = SimpleFloorPlanner;
 
         fn without_witnesses(&self) -> Self {
-            MulSignCircuit {
+            MyMulSignCircuit {
                 base: Value::unknown(),
                 sign: Value::unknown(),
                 _lookup_marker: PhantomData,
@@ -900,12 +900,12 @@ pub mod tests {
         }
     }
 
-    impl<Lookup: PallasLookupRangeCheck> MulSignCircuit<Lookup> {
+    impl<Lookup: PallasLookupRangeCheck> MyMulSignCircuit<Lookup> {
         fn test_invalid_magnitude_sign() {
             // Sign that is not +/- 1 should fail
             // Generate a random non-identity point
             let point = pallas::Point::random(rand::rngs::OsRng);
-            let circuit: MulSignCircuit<Lookup> = MulSignCircuit {
+            let circuit: MyMulSignCircuit<Lookup> = MyMulSignCircuit {
                 base: Value::known(point.to_affine()),
                 sign: Value::known(pallas::Base::zero()),
                 _lookup_marker: PhantomData,
@@ -954,10 +954,10 @@ pub mod tests {
 
     #[test]
     fn invalid_sign_in_mul_sign() {
-        MulSignCircuit::<PallasLookupRangeCheckConfig>::test_invalid_magnitude_sign();
+        MyMulSignCircuit::<PallasLookupRangeCheckConfig>::test_invalid_magnitude_sign();
     }
     #[test]
     fn invalid_sign_in_mul_sign_4_5b() {
-        MulSignCircuit::<PallasLookupRangeCheck4_5BConfig>::test_invalid_magnitude_sign();
+        MyMulSignCircuit::<PallasLookupRangeCheck4_5BConfig>::test_invalid_magnitude_sign();
     }
 }

--- a/halo2_gadgets/src/ecc/chip/mul_fixed/short.rs
+++ b/halo2_gadgets/src/ecc/chip/mul_fixed/short.rs
@@ -244,7 +244,7 @@ impl<Fixed: FixedPoints<pallas::Affine>> Config<Fixed> {
 
     /// Multiply the point by sign, using the q_mul_fixed_short gate.
     /// Constraints `sign` in {-1, 1}
-    pub fn assign_scalar_sign(
+    pub(crate) fn assign_scalar_sign(
         &self,
         mut layouter: impl Layouter<pallas::Base>,
         sign: &AssignedCell<pallas::Base, pallas::Base>,

--- a/halo2_gadgets/src/poseidon/pow5.rs
+++ b/halo2_gadgets/src/poseidon/pow5.rs
@@ -618,18 +618,18 @@ mod tests {
     use std::convert::TryInto;
     use std::marker::PhantomData;
 
-    struct PermuteCircuit<S: Spec<Fp, WIDTH, RATE>, const WIDTH: usize, const RATE: usize>(
+    struct MyPermuteCircuit<S: Spec<Fp, WIDTH, RATE>, const WIDTH: usize, const RATE: usize>(
         PhantomData<S>,
     );
 
     impl<S: Spec<Fp, WIDTH, RATE>, const WIDTH: usize, const RATE: usize> Circuit<Fp>
-        for PermuteCircuit<S, WIDTH, RATE>
+        for MyPermuteCircuit<S, WIDTH, RATE>
     {
         type Config = Pow5Config<Fp, WIDTH, RATE>;
         type FloorPlanner = SimpleFloorPlanner;
 
         fn without_witnesses(&self) -> Self {
-            PermuteCircuit::<S, WIDTH, RATE>(PhantomData)
+            MyPermuteCircuit::<S, WIDTH, RATE>(PhantomData)
         }
 
         fn configure(meta: &mut ConstraintSystem<Fp>) -> Pow5Config<Fp, WIDTH, RATE> {
@@ -719,12 +719,12 @@ mod tests {
     #[test]
     fn poseidon_permute() {
         let k = 6;
-        let circuit = PermuteCircuit::<OrchardNullifier, 3, 2>(PhantomData);
+        let circuit = MyPermuteCircuit::<OrchardNullifier, 3, 2>(PhantomData);
         let prover = MockProver::run(k, &circuit, vec![]).unwrap();
         assert_eq!(prover.verify(), Ok(()))
     }
 
-    struct HashCircuit<
+    struct MyHashCircuit<
         S: Spec<Fp, WIDTH, RATE>,
         const WIDTH: usize,
         const RATE: usize,
@@ -738,7 +738,7 @@ mod tests {
     }
 
     impl<S: Spec<Fp, WIDTH, RATE>, const WIDTH: usize, const RATE: usize, const L: usize>
-        Circuit<Fp> for HashCircuit<S, WIDTH, RATE, L>
+        Circuit<Fp> for MyHashCircuit<S, WIDTH, RATE, L>
     {
         type Config = Pow5Config<Fp, WIDTH, RATE>;
         type FloorPlanner = SimpleFloorPlanner;
@@ -824,7 +824,7 @@ mod tests {
             poseidon::Hash::<_, OrchardNullifier, ConstantLength<2>, 3, 2>::init().hash(message);
 
         let k = 6;
-        let circuit = HashCircuit::<OrchardNullifier, 3, 2, 2> {
+        let circuit = MyHashCircuit::<OrchardNullifier, 3, 2, 2> {
             message: Value::known(message),
             output: Value::known(output),
             _spec: PhantomData,
@@ -842,7 +842,7 @@ mod tests {
             poseidon::Hash::<_, OrchardNullifier, ConstantLength<3>, 3, 2>::init().hash(message);
 
         let k = 7;
-        let circuit = HashCircuit::<OrchardNullifier, 3, 2, 3> {
+        let circuit = MyHashCircuit::<OrchardNullifier, 3, 2, 3> {
             message: Value::known(message),
             output: Value::known(output),
             _spec: PhantomData,
@@ -884,7 +884,7 @@ mod tests {
                 .hash(message);
 
             let k = 6;
-            let circuit = HashCircuit::<OrchardNullifier, 3, 2, 2> {
+            let circuit = MyHashCircuit::<OrchardNullifier, 3, 2, 2> {
                 message: Value::known(message),
                 output: Value::known(output),
                 _spec: PhantomData,
@@ -905,7 +905,7 @@ mod tests {
             .titled("Poseidon Chip Layout", ("sans-serif", 60))
             .unwrap();
 
-        let circuit = HashCircuit::<OrchardNullifier, 3, 2, 2> {
+        let circuit = MyHashCircuit::<OrchardNullifier, 3, 2, 2> {
             message: Value::unknown(),
             output: Value::unknown(),
             _spec: PhantomData,

--- a/halo2_gadgets/src/sinsemilla.rs
+++ b/halo2_gadgets/src/sinsemilla.rs
@@ -586,11 +586,11 @@ pub(crate) mod tests {
         }
     }
 
-    struct SinsemillaCircuit<Lookup: PallasLookupRangeCheck> {
+    struct MySinsemillaCircuit<Lookup: PallasLookupRangeCheck> {
         _lookup_marker: PhantomData<Lookup>,
     }
 
-    impl<Lookup: PallasLookupRangeCheck> SinsemillaCircuit<Lookup> {
+    impl<Lookup: PallasLookupRangeCheck> MySinsemillaCircuit<Lookup> {
         fn new() -> Self {
             Self {
                 _lookup_marker: PhantomData,
@@ -808,12 +808,12 @@ pub(crate) mod tests {
         }
     }
 
-    impl<Lookup: PallasLookupRangeCheck> Circuit<pallas::Base> for SinsemillaCircuit<Lookup> {
+    impl<Lookup: PallasLookupRangeCheck> Circuit<pallas::Base> for MySinsemillaCircuit<Lookup> {
         type Config = EccSinsemillaConfig<Lookup>;
         type FloorPlanner = SimpleFloorPlanner;
 
         fn without_witnesses(&self) -> Self {
-            SinsemillaCircuit::new()
+            MySinsemillaCircuit::new()
         }
 
         #[allow(non_snake_case)]
@@ -833,14 +833,14 @@ pub(crate) mod tests {
     #[test]
     fn sinsemilla_chip() {
         let k = 11;
-        let circuit = SinsemillaCircuit::<PallasLookupRangeCheckConfig>::new();
+        let circuit = MySinsemillaCircuit::<PallasLookupRangeCheckConfig>::new();
         let prover = MockProver::run(k, &circuit, vec![]).unwrap();
         assert_eq!(prover.verify(), Ok(()))
     }
 
     #[test]
     fn test_sinsemilla_chip_against_stored_circuit() {
-        let circuit = SinsemillaCircuit::<PallasLookupRangeCheckConfig>::new();
+        let circuit = MySinsemillaCircuit::<PallasLookupRangeCheckConfig>::new();
         test_against_stored_circuit(circuit, "sinsemilla_chip", 4576);
     }
 
@@ -854,17 +854,17 @@ pub(crate) mod tests {
         root.fill(&WHITE).unwrap();
         let root = root.titled("SinsemillaHash", ("sans-serif", 60)).unwrap();
 
-        let circuit = SinsemillaCircuit::<PallasLookupRangeCheckConfig>::new();
+        let circuit = MySinsemillaCircuit::<PallasLookupRangeCheckConfig>::new();
         halo2_proofs::dev::CircuitLayout::default()
             .render(11, &circuit, &root)
             .unwrap();
     }
 
-    struct SinsemillaCircuitWithHashFromPrivatePoint<Lookup: PallasLookupRangeCheck> {
+    struct MySinsemillaCircuitWithHashFromPrivatePoint<Lookup: PallasLookupRangeCheck> {
         _lookup_marker: PhantomData<Lookup>,
     }
 
-    impl<Lookup: PallasLookupRangeCheck> SinsemillaCircuitWithHashFromPrivatePoint<Lookup> {
+    impl<Lookup: PallasLookupRangeCheck> MySinsemillaCircuitWithHashFromPrivatePoint<Lookup> {
         fn new() -> Self {
             Self {
                 _lookup_marker: PhantomData,
@@ -873,13 +873,13 @@ pub(crate) mod tests {
     }
 
     impl<Lookup: PallasLookupRangeCheck> Circuit<pallas::Base>
-        for SinsemillaCircuitWithHashFromPrivatePoint<Lookup>
+        for MySinsemillaCircuitWithHashFromPrivatePoint<Lookup>
     {
         type Config = EccSinsemillaConfig<Lookup>;
         type FloorPlanner = SimpleFloorPlanner;
 
         fn without_witnesses(&self) -> Self {
-            SinsemillaCircuitWithHashFromPrivatePoint::new()
+            MySinsemillaCircuitWithHashFromPrivatePoint::new()
         }
 
         #[allow(non_snake_case)]
@@ -900,7 +900,7 @@ pub(crate) mod tests {
     fn sinsemilla_with_hash_from_private_point_chip_4_5b() {
         let k = 11;
         let circuit =
-            SinsemillaCircuitWithHashFromPrivatePoint::<PallasLookupRangeCheck4_5BConfig>::new();
+            MySinsemillaCircuitWithHashFromPrivatePoint::<PallasLookupRangeCheck4_5BConfig>::new();
         let prover = MockProver::run(k, &circuit, vec![]).unwrap();
         assert_eq!(prover.verify(), Ok(()))
     }
@@ -908,7 +908,7 @@ pub(crate) mod tests {
     #[test]
     fn test_against_stored_sinsemilla_with_hash_from_private_point_chip_4_5b() {
         let circuit =
-            SinsemillaCircuitWithHashFromPrivatePoint::<PallasLookupRangeCheck4_5BConfig>::new();
+            MySinsemillaCircuitWithHashFromPrivatePoint::<PallasLookupRangeCheck4_5BConfig>::new();
         test_against_stored_circuit(circuit, "sinsemilla_with_private_init_chip_4_5b", 4672);
     }
 
@@ -923,7 +923,7 @@ pub(crate) mod tests {
         let root = root.titled("SinsemillaHash", ("sans-serif", 60)).unwrap();
 
         let circuit =
-            SinsemillaCircuitWithHashFromPrivatePoint::<PallasLookupRangeCheck4_5BConfig>::new();
+            MySinsemillaCircuitWithHashFromPrivatePoint::<PallasLookupRangeCheck4_5BConfig>::new();
         halo2_proofs::dev::CircuitLayout::default()
             .render(11, &circuit, &root)
             .unwrap();

--- a/halo2_gadgets/src/sinsemilla/chip.rs
+++ b/halo2_gadgets/src/sinsemilla/chip.rs
@@ -23,7 +23,7 @@ use halo2_proofs::{
 };
 use pasta_curves::pallas;
 
-mod generator_table;
+pub(crate) mod generator_table;
 use generator_table::GeneratorTableConfig;
 
 mod hash_to_point;
@@ -153,9 +153,7 @@ where
         layouter: &mut impl Layouter<pallas::Base>,
     ) -> Result<<Self as Chip<pallas::Base>>::Loaded, Error> {
         // Load the lookup table.
-        config
-            .generator_table
-            .load(config.lookup_config.table_range_check_tag(), layouter)
+        config.generator_table.load(config.lookup_config, layouter)
     }
 
     /// Creates the Sinsemilla chip

--- a/halo2_gadgets/src/sinsemilla/chip.rs
+++ b/halo2_gadgets/src/sinsemilla/chip.rs
@@ -285,6 +285,7 @@ where
 
             Constraints::with_selector(q_s1, [("Secant line", secant_line), ("y check", y_check)])
         });
+
         config
     }
 }

--- a/halo2_gadgets/src/sinsemilla/chip/generator_table.rs
+++ b/halo2_gadgets/src/sinsemilla/chip/generator_table.rs
@@ -101,10 +101,7 @@ impl GeneratorTableConfig {
     /// |     1     |    X(S\[1\])   |    Y(S\[1\])   |
     /// |    ...    |      ...       |       ...      |
     /// |   2^10-1  | X(S\[2^10-1\]) | Y(S\[2^10-1\]) |
-    pub fn load_without_tag(
-        &self,
-        layouter: &mut impl Layouter<pallas::Base>,
-    ) -> Result<(), Error> {
+    fn load_without_tag(&self, layouter: &mut impl Layouter<pallas::Base>) -> Result<(), Error> {
         layouter.assign_table(
             || "generator_table",
             |mut table| {
@@ -139,7 +136,7 @@ impl GeneratorTableConfig {
     /// |     1     |    X(S\[1\])   |    Y(S\[1\])   |           5           |
     /// |    ...    |       ...      |       ...      |           5           |
     /// |   2^5-1   | X(S\[2^5-1\])  | Y(S\[2^5-1\])  |           5           |
-    pub fn load_with_tag(
+    fn load_with_tag(
         &self,
         table_range_check_tag: TableColumn,
         layouter: &mut impl Layouter<pallas::Base>,

--- a/halo2_gadgets/src/sinsemilla/chip/generator_table.rs
+++ b/halo2_gadgets/src/sinsemilla/chip/generator_table.rs
@@ -1,14 +1,15 @@
+use ff::PrimeFieldBits;
 use group::ff::PrimeField;
 use halo2_proofs::{
-    circuit::{Layouter, Value},
+    circuit::Layouter,
     plonk::{ConstraintSystem, Error, Expression, TableColumn},
     poly::Rotation,
 };
 
 use super::{CommitDomains, FixedPoints, HashDomains};
 use crate::{
-    sinsemilla::primitives::{self as sinsemilla, K, SINSEMILLA_S},
-    utilities::lookup_range_check::PallasLookupRangeCheck,
+    sinsemilla::primitives::{self as sinsemilla, SINSEMILLA_S},
+    utilities::lookup_range_check::{LookupRangeCheck, PallasLookupRangeCheck},
 };
 use pasta_curves::pallas;
 
@@ -82,141 +83,14 @@ impl GeneratorTableConfig {
     }
 
     /// Load the generator table into the circuit.
-    pub fn load(
+    pub fn load<F, const K: usize>(
         &self,
-        table_range_check_tag: Option<TableColumn>,
+        lookup_config: impl LookupRangeCheck<F, K>,
         layouter: &mut impl Layouter<pallas::Base>,
-    ) -> Result<(), Error> {
-        match table_range_check_tag {
-            Some(tag) => self.load_with_tag(tag, layouter),
-            None => self.load_without_tag(layouter),
-        }
-    }
-
-    /// Load the generator table into the circuit.
-    ///
-    /// | table_idx |     table_x    |     table_y    |
-    /// ------------------------------------------------
-    /// |     0     |    X(S\[0\])   |    Y(S\[0\])   |
-    /// |     1     |    X(S\[1\])   |    Y(S\[1\])   |
-    /// |    ...    |      ...       |       ...      |
-    /// |   2^10-1  | X(S\[2^10-1\]) | Y(S\[2^10-1\]) |
-    fn load_without_tag(&self, layouter: &mut impl Layouter<pallas::Base>) -> Result<(), Error> {
-        layouter.assign_table(
-            || "generator_table",
-            |mut table| {
-                for (index, (x, y)) in SINSEMILLA_S.iter().enumerate() {
-                    table.assign_cell(
-                        || "table_idx",
-                        self.table_idx,
-                        index,
-                        || Value::known(pallas::Base::from(index as u64)),
-                    )?;
-                    table.assign_cell(|| "table_x", self.table_x, index, || Value::known(*x))?;
-                    table.assign_cell(|| "table_y", self.table_y, index, || Value::known(*y))?;
-                }
-                Ok(())
-            },
-        )
-    }
-
-    /// Load the generator table into the circuit.
-    ///
-    /// | table_idx |     table_x    |     table_y    | table_range_check_tag |
-    /// -------------------------------------------------------------------
-    /// |     0     |    X(S\[0\])   |    Y(S\[0\])   |           0           |
-    /// |     1     |    X(S\[1\])   |    Y(S\[1\])   |           0           |
-    /// |    ...    |      ...       |       ...      |           0           |
-    /// |   2^10-1  | X(S\[2^10-1\]) | Y(S\[2^10-1\]) |           0           |
-    /// |     0     |    X(S\[0\])   |    Y(S\[0\])   |           4           |
-    /// |     1     |    X(S\[1\])   |    Y(S\[1\])   |           4           |
-    /// |    ...    |       ...      |       ...      |           4           |
-    /// |   2^4-1   | X(S\[2^4-1\])  | Y(S\[2^4-1\])  |           4           |
-    /// |     0     |    X(S\[0\])   |    Y(S\[0\])   |           5           |
-    /// |     1     |    X(S\[1\])   |    Y(S\[1\])   |           5           |
-    /// |    ...    |       ...      |       ...      |           5           |
-    /// |   2^5-1   | X(S\[2^5-1\])  | Y(S\[2^5-1\])  |           5           |
-    fn load_with_tag(
-        &self,
-        table_range_check_tag: TableColumn,
-        layouter: &mut impl Layouter<pallas::Base>,
-    ) -> Result<(), Error> {
-        layouter.assign_table(
-            || "generator_table",
-            |mut table| {
-                for (index, (x, y)) in SINSEMILLA_S.iter().enumerate() {
-                    table.assign_cell(
-                        || "table_idx",
-                        self.table_idx,
-                        index,
-                        || Value::known(pallas::Base::from(index as u64)),
-                    )?;
-                    table.assign_cell(|| "table_x", self.table_x, index, || Value::known(*x))?;
-                    table.assign_cell(|| "table_y", self.table_y, index, || Value::known(*y))?;
-
-                    table.assign_cell(
-                        || "table_range_check_tag",
-                        table_range_check_tag,
-                        index,
-                        || Value::known(pallas::Base::zero()),
-                    )?;
-                    if index < (1 << 4) {
-                        let new_index = index + (1 << K);
-                        table.assign_cell(
-                            || "table_idx",
-                            self.table_idx,
-                            new_index,
-                            || Value::known(pallas::Base::from(index as u64)),
-                        )?;
-                        table.assign_cell(
-                            || "table_x",
-                            self.table_x,
-                            new_index,
-                            || Value::known(*x),
-                        )?;
-                        table.assign_cell(
-                            || "table_y",
-                            self.table_y,
-                            new_index,
-                            || Value::known(*y),
-                        )?;
-                        table.assign_cell(
-                            || "table_range_check_tag",
-                            table_range_check_tag,
-                            new_index,
-                            || Value::known(pallas::Base::from(4_u64)),
-                        )?;
-                    }
-                    if index < (1 << 5) {
-                        let new_index = index + (1 << 10) + (1 << 4);
-                        table.assign_cell(
-                            || "table_idx",
-                            self.table_idx,
-                            new_index,
-                            || Value::known(pallas::Base::from(index as u64)),
-                        )?;
-                        table.assign_cell(
-                            || "table_x",
-                            self.table_x,
-                            new_index,
-                            || Value::known(*x),
-                        )?;
-                        table.assign_cell(
-                            || "table_y",
-                            self.table_y,
-                            new_index,
-                            || Value::known(*y),
-                        )?;
-                        table.assign_cell(
-                            || "table_range_check_tag",
-                            table_range_check_tag,
-                            new_index,
-                            || Value::known(pallas::Base::from(5_u64)),
-                        )?;
-                    }
-                }
-                Ok(())
-            },
-        )
+    ) -> Result<(), Error>
+    where
+        F: PrimeFieldBits,
+    {
+        lookup_config.load(self, layouter)
     }
 }

--- a/halo2_gadgets/src/sinsemilla/chip/hash_to_point.rs
+++ b/halo2_gadgets/src/sinsemilla/chip/hash_to_point.rs
@@ -1,7 +1,7 @@
 use super::super::{CommitDomains, HashDomains, SinsemillaInstructions};
+use super::{NonIdentityEccPoint, SinsemillaChip};
 use crate::{
     ecc::FixedPoints,
-    sinsemilla::chip::{NonIdentityEccPoint, SinsemillaChip},
     sinsemilla::primitives::{self as sinsemilla, lebs2ip_k, INV_TWO_POW_K, SINSEMILLA_S},
     utilities::lookup_range_check::PallasLookupRangeCheck,
 };

--- a/halo2_gadgets/src/sinsemilla/merkle.rs
+++ b/halo2_gadgets/src/sinsemilla/merkle.rs
@@ -210,14 +210,14 @@ pub mod tests {
     const MERKLE_DEPTH: usize = 32;
 
     #[derive(Default)]
-    struct MerkleCircuit<Lookup: PallasLookupRangeCheck> {
+    struct MyMerkleCircuit<Lookup: PallasLookupRangeCheck> {
         leaf: Value<pallas::Base>,
         leaf_pos: Value<u32>,
         merkle_path: Value<[pallas::Base; MERKLE_DEPTH]>,
         _lookup_marker: PhantomData<Lookup>,
     }
 
-    impl<Lookup: PallasLookupRangeCheck> MerkleCircuit<Lookup> {
+    impl<Lookup: PallasLookupRangeCheck> MyMerkleCircuit<Lookup> {
         fn new(
             leaf: Value<pallas::Base>,
             leaf_pos: Value<u32>,
@@ -296,7 +296,7 @@ pub mod tests {
         (config1, config2)
     }
 
-    impl<Lookup: PallasLookupRangeCheck> Circuit<pallas::Base> for MerkleCircuit<Lookup> {
+    impl<Lookup: PallasLookupRangeCheck> Circuit<pallas::Base> for MyMerkleCircuit<Lookup> {
         type Config = (
             MerkleConfig<TestHashDomain, TestCommitDomain, TestFixedBases, Lookup>,
             MerkleConfig<TestHashDomain, TestCommitDomain, TestFixedBases, Lookup>,
@@ -304,7 +304,7 @@ pub mod tests {
         type FloorPlanner = SimpleFloorPlanner;
 
         fn without_witnesses(&self) -> Self {
-            MerkleCircuit::new(Value::default(), Value::default(), Value::default())
+            MyMerkleCircuit::new(Value::default(), Value::default(), Value::default())
         }
 
         fn configure(meta: &mut ConstraintSystem<pallas::Base>) -> Self::Config {
@@ -392,7 +392,7 @@ pub mod tests {
         }
     }
 
-    fn generate_circuit<Lookup: PallasLookupRangeCheck>() -> MerkleCircuit<Lookup> {
+    fn generate_circuit<Lookup: PallasLookupRangeCheck>() -> MyMerkleCircuit<Lookup> {
         let mut rng = OsRng;
 
         // Choose a random leaf and position
@@ -405,7 +405,7 @@ pub mod tests {
             .collect();
 
         // The root is provided as a public input in the Orchard circuit.
-        MerkleCircuit::new(
+        MyMerkleCircuit::new(
             Value::known(leaf),
             Value::known(pos),
             Value::known(path.try_into().unwrap()),
@@ -414,7 +414,7 @@ pub mod tests {
 
     #[test]
     fn merkle_chip() {
-        let circuit: MerkleCircuit<PallasLookupRangeCheckConfig> = generate_circuit();
+        let circuit: MyMerkleCircuit<PallasLookupRangeCheckConfig> = generate_circuit();
 
         let prover = MockProver::run(11, &circuit, vec![]).unwrap();
         assert_eq!(prover.verify(), Ok(()))
@@ -422,7 +422,7 @@ pub mod tests {
 
     #[test]
     fn test_merkle_chip_against_stored_circuit() {
-        let circuit: MerkleCircuit<PallasLookupRangeCheckConfig> = generate_circuit();
+        let circuit: MyMerkleCircuit<PallasLookupRangeCheckConfig> = generate_circuit();
         test_against_stored_circuit(circuit, "merkle_chip", 4160);
     }
 
@@ -435,7 +435,7 @@ pub mod tests {
         root.fill(&WHITE).unwrap();
         let root = root.titled("MerkleCRH Path", ("sans-serif", 60)).unwrap();
 
-        let circuit: MerkleCircuit<PallasLookupRangeCheckConfig> = MerkleCircuit {
+        let circuit: MyMerkleCircuit<PallasLookupRangeCheckConfig> = MyMerkleCircuit {
             leaf: Value::default(),
             leaf_pos: Value::default(),
             merkle_path: Value::default(),
@@ -448,14 +448,14 @@ pub mod tests {
     }
 
     #[derive(Default)]
-    struct MerkleCircuitWithHashFromPrivatePoint<Lookup: PallasLookupRangeCheck> {
+    struct MyMerkleCircuitWithHashFromPrivatePoint<Lookup: PallasLookupRangeCheck> {
         leaf: Value<pallas::Base>,
         leaf_pos: Value<u32>,
         merkle_path: Value<[pallas::Base; MERKLE_DEPTH]>,
         _lookup_marker: PhantomData<Lookup>,
     }
 
-    impl<Lookup: PallasLookupRangeCheck> MerkleCircuitWithHashFromPrivatePoint<Lookup> {
+    impl<Lookup: PallasLookupRangeCheck> MyMerkleCircuitWithHashFromPrivatePoint<Lookup> {
         fn new(
             leaf: Value<pallas::Base>,
             leaf_pos: Value<u32>,
@@ -471,7 +471,7 @@ pub mod tests {
     }
 
     impl<Lookup: PallasLookupRangeCheck> Circuit<pallas::Base>
-        for MerkleCircuitWithHashFromPrivatePoint<Lookup>
+        for MyMerkleCircuitWithHashFromPrivatePoint<Lookup>
     {
         type Config = (
             MerkleConfig<TestHashDomain, TestCommitDomain, TestFixedBases, Lookup>,
@@ -480,7 +480,7 @@ pub mod tests {
         type FloorPlanner = SimpleFloorPlanner;
 
         fn without_witnesses(&self) -> Self {
-            MerkleCircuitWithHashFromPrivatePoint::new(
+            MyMerkleCircuitWithHashFromPrivatePoint::new(
                 Value::default(),
                 Value::default(),
                 Value::default(),
@@ -573,7 +573,7 @@ pub mod tests {
     }
 
     fn generate_circuit_4_5b<Lookup: PallasLookupRangeCheck>(
-    ) -> MerkleCircuitWithHashFromPrivatePoint<Lookup> {
+    ) -> MyMerkleCircuitWithHashFromPrivatePoint<Lookup> {
         let mut rng = OsRng;
 
         // Choose a random leaf and position
@@ -586,7 +586,7 @@ pub mod tests {
             .collect();
 
         // The root is provided as a public input in the Orchard circuit.
-        MerkleCircuitWithHashFromPrivatePoint::new(
+        MyMerkleCircuitWithHashFromPrivatePoint::new(
             Value::known(leaf),
             Value::known(pos),
             Value::known(path.try_into().unwrap()),
@@ -594,7 +594,7 @@ pub mod tests {
     }
     #[test]
     fn merkle_with_hash_from_private_point_chip_4_5b() {
-        let circuit: MerkleCircuitWithHashFromPrivatePoint<PallasLookupRangeCheck4_5BConfig> =
+        let circuit: MyMerkleCircuitWithHashFromPrivatePoint<PallasLookupRangeCheck4_5BConfig> =
             generate_circuit_4_5b();
 
         let prover = MockProver::run(11, &circuit, vec![]).unwrap();
@@ -603,7 +603,7 @@ pub mod tests {
 
     #[test]
     fn test_against_stored_merkle_with_hash_from_private_point_chip_4_5b() {
-        let circuit: MerkleCircuitWithHashFromPrivatePoint<PallasLookupRangeCheck4_5BConfig> =
+        let circuit: MyMerkleCircuitWithHashFromPrivatePoint<PallasLookupRangeCheck4_5BConfig> =
             generate_circuit_4_5b();
 
         test_against_stored_circuit(circuit, "merkle_with_private_init_chip_4_5b", 4160);
@@ -622,8 +622,8 @@ pub mod tests {
         root.fill(&WHITE).unwrap();
         let root = root.titled("MerkleCRH Path", ("sans-serif", 60)).unwrap();
 
-        let circuit: MerkleCircuitWithHashFromPrivatePoint<PallasLookupRangeCheck4_5BConfig> =
-            MerkleCircuitWithHashFromPrivatePoint::new(
+        let circuit: MyMerkleCircuitWithHashFromPrivatePoint<PallasLookupRangeCheck4_5BConfig> =
+            MyMerkleCircuitWithHashFromPrivatePoint::new(
                 Value::default(),
                 Value::default(),
                 Value::default(),

--- a/halo2_gadgets/src/tests.rs
+++ b/halo2_gadgets/src/tests.rs
@@ -1,1 +1,0 @@
-pub(crate) mod test_utils;

--- a/halo2_gadgets/src/utilities/cond_swap.rs
+++ b/halo2_gadgets/src/utilities/cond_swap.rs
@@ -317,13 +317,13 @@ mod tests {
     #[test]
     fn cond_swap() {
         #[derive(Default)]
-        struct CondSwapCircuit<F: Field> {
+        struct MyCondSwapCircuit<F: Field> {
             a: Value<F>,
             b: Value<F>,
             swap: Value<bool>,
         }
 
-        impl<F: PrimeField> Circuit<F> for CondSwapCircuit<F> {
+        impl<F: PrimeField> Circuit<F> for MyCondSwapCircuit<F> {
             type Config = CondSwapConfig;
             type FloorPlanner = SimpleFloorPlanner;
 
@@ -380,7 +380,7 @@ mod tests {
 
         // Test swap case
         {
-            let circuit: CondSwapCircuit<Base> = CondSwapCircuit {
+            let circuit: MyCondSwapCircuit<Base> = MyCondSwapCircuit {
                 a: Value::known(Base::random(rng)),
                 b: Value::known(Base::random(rng)),
                 swap: Value::known(true),
@@ -391,7 +391,7 @@ mod tests {
 
         // Test non-swap case
         {
-            let circuit: CondSwapCircuit<Base> = CondSwapCircuit {
+            let circuit: MyCondSwapCircuit<Base> = MyCondSwapCircuit {
                 a: Value::known(Base::random(rng)),
                 b: Value::known(Base::random(rng)),
                 swap: Value::known(false),
@@ -428,20 +428,20 @@ mod tests {
         }
 
         #[derive(Default)]
-        struct MuxCircuit<Lookup: PallasLookupRangeCheck> {
+        struct MyMuxCircuit<Lookup: PallasLookupRangeCheck> {
             left_point: Value<EpAffine>,
             right_point: Value<EpAffine>,
             choice: Value<pallas::Base>,
             _lookup_marker: PhantomData<Lookup>,
         }
 
-        impl<Lookup: PallasLookupRangeCheck> MuxCircuit<Lookup> {
+        impl<Lookup: PallasLookupRangeCheck> MyMuxCircuit<Lookup> {
             fn new(
                 left_point: Value<EpAffine>,
                 right_point: Value<EpAffine>,
                 choice: Value<pallas::Base>,
             ) -> Self {
-                MuxCircuit {
+                MyMuxCircuit {
                     left_point,
                     right_point,
                     choice,
@@ -450,12 +450,12 @@ mod tests {
             }
         }
 
-        impl<Lookup: PallasLookupRangeCheck> Circuit<pallas::Base> for MuxCircuit<Lookup> {
+        impl<Lookup: PallasLookupRangeCheck> Circuit<pallas::Base> for MyMuxCircuit<Lookup> {
             type Config = MuxConfig<Lookup>;
             type FloorPlanner = SimpleFloorPlanner;
 
             fn without_witnesses(&self) -> Self {
-                MuxCircuit::<Lookup>::new(Value::default(), Value::default(), Value::default())
+                MyMuxCircuit::<Lookup>::new(Value::default(), Value::default(), Value::default())
             }
 
             fn configure(meta: &mut ConstraintSystem<pallas::Base>) -> Self::Config {
@@ -597,7 +597,7 @@ mod tests {
             }
         }
 
-        impl<Lookup: PallasLookupRangeCheck> MuxCircuit<Lookup> {
+        impl<Lookup: PallasLookupRangeCheck> MyMuxCircuit<Lookup> {
             fn test_mux_circuits() {
                 // Test different circuits
                 let mut circuits = vec![];
@@ -610,7 +610,7 @@ mod tests {
                     };
                     let left_point = pallas::Point::random(OsRng).to_affine();
                     let right_point = pallas::Point::random(OsRng).to_affine();
-                    circuits.push(MuxCircuit::<Lookup> {
+                    circuits.push(MyMuxCircuit::<Lookup> {
                         left_point: Value::known(left_point),
                         right_point: Value::known(right_point),
                         choice: Value::known(choice_value),
@@ -638,7 +638,7 @@ mod tests {
             }
         }
 
-        MuxCircuit::<PallasLookupRangeCheckConfig>::test_mux_circuits();
-        MuxCircuit::<PallasLookupRangeCheck4_5BConfig>::test_mux_circuits();
+        MyMuxCircuit::<PallasLookupRangeCheckConfig>::test_mux_circuits();
+        MyMuxCircuit::<PallasLookupRangeCheck4_5BConfig>::test_mux_circuits();
     }
 }

--- a/halo2_gadgets/src/utilities/lookup_range_check.rs
+++ b/halo2_gadgets/src/utilities/lookup_range_check.rs
@@ -862,14 +862,14 @@ mod tests {
     use std::{convert::TryInto, marker::PhantomData};
 
     #[derive(Clone, Copy)]
-    struct LookupCircuit<F: PrimeFieldBits, Lookup: LookupRangeCheck<F, K>> {
+    struct MyLookupCircuit<F: PrimeFieldBits, Lookup: LookupRangeCheck<F, K>> {
         num_words: usize,
         _marker: PhantomData<(F, Lookup)>,
     }
 
-    impl<F: PrimeFieldBits, Lookup: LookupRangeCheck<F, K>> LookupCircuit<F, Lookup> {
+    impl<F: PrimeFieldBits, Lookup: LookupRangeCheck<F, K>> MyLookupCircuit<F, Lookup> {
         fn new(num_words: usize) -> Self {
-            LookupCircuit {
+            MyLookupCircuit {
                 num_words,
                 _marker: PhantomData,
             }
@@ -877,13 +877,13 @@ mod tests {
     }
 
     impl<F: PrimeFieldBits, Lookup: LookupRangeCheck<F, K> + std::clone::Clone> Circuit<F>
-        for LookupCircuit<F, Lookup>
+        for MyLookupCircuit<F, Lookup>
     {
         type Config = Lookup;
         type FloorPlanner = SimpleFloorPlanner;
 
         fn without_witnesses(&self) -> Self {
-            LookupCircuit::new(self.num_words)
+            MyLookupCircuit::new(self.num_words)
         }
 
         fn configure(meta: &mut ConstraintSystem<F>) -> Self::Config {
@@ -958,40 +958,40 @@ mod tests {
 
     #[test]
     fn lookup_range_check() {
-        let circuit = LookupCircuit::<pallas::Base, PallasLookupRangeCheckConfig>::new(6);
+        let circuit = MyLookupCircuit::<pallas::Base, PallasLookupRangeCheckConfig>::new(6);
         let prover = MockProver::<pallas::Base>::run(11, &circuit, vec![]).unwrap();
         assert_eq!(prover.verify(), Ok(()));
     }
 
     #[test]
     fn test_lookup_range_check_against_stored_circuit() {
-        let circuit = LookupCircuit::<pallas::Base, PallasLookupRangeCheckConfig>::new(6);
+        let circuit = MyLookupCircuit::<pallas::Base, PallasLookupRangeCheckConfig>::new(6);
         test_against_stored_circuit(circuit, "lookup_range_check", 1888);
     }
 
     #[test]
     fn lookup_range_check_4_5b() {
-        let circuit = LookupCircuit::<pallas::Base, PallasLookupRangeCheck4_5BConfig>::new(6);
+        let circuit = MyLookupCircuit::<pallas::Base, PallasLookupRangeCheck4_5BConfig>::new(6);
         let prover = MockProver::<pallas::Base>::run(11, &circuit, vec![]).unwrap();
         assert_eq!(prover.verify(), Ok(()));
     }
 
     #[test]
     fn test_lookup_range_check_against_stored_circuit_4_5b() {
-        let circuit = LookupCircuit::<pallas::Base, PallasLookupRangeCheck4_5BConfig>::new(6);
+        let circuit = MyLookupCircuit::<pallas::Base, PallasLookupRangeCheck4_5BConfig>::new(6);
         test_against_stored_circuit(circuit, "lookup_range_check_4_5b", 2048);
     }
 
     #[derive(Clone, Copy)]
-    struct ShortRangeCheckCircuit<F: PrimeFieldBits, Lookup: LookupRangeCheck<F, K>> {
+    struct MyShortRangeCheckCircuit<F: PrimeFieldBits, Lookup: LookupRangeCheck<F, K>> {
         element: Value<F>,
         num_bits: usize,
         _lookup_marker: PhantomData<Lookup>,
     }
 
-    impl<F: PrimeFieldBits, Lookup: LookupRangeCheck<F, K>> ShortRangeCheckCircuit<F, Lookup> {
+    impl<F: PrimeFieldBits, Lookup: LookupRangeCheck<F, K>> MyShortRangeCheckCircuit<F, Lookup> {
         fn new(element: Value<F>, num_bits: usize) -> Self {
-            ShortRangeCheckCircuit {
+            MyShortRangeCheckCircuit {
                 element,
                 num_bits,
                 _lookup_marker: PhantomData,
@@ -1000,13 +1000,13 @@ mod tests {
     }
 
     impl<F: PrimeFieldBits, Lookup: LookupRangeCheck<F, K> + std::clone::Clone> Circuit<F>
-        for ShortRangeCheckCircuit<F, Lookup>
+        for MyShortRangeCheckCircuit<F, Lookup>
     {
         type Config = Lookup;
         type FloorPlanner = SimpleFloorPlanner;
 
         fn without_witnesses(&self) -> Self {
-            ShortRangeCheckCircuit::new(Value::unknown(), self.num_bits)
+            MyShortRangeCheckCircuit::new(Value::unknown(), self.num_bits)
         }
 
         fn configure(meta: &mut ConstraintSystem<F>) -> Self::Config {
@@ -1045,7 +1045,7 @@ mod tests {
         expected_proof_size: usize,
     ) {
         let circuit =
-            ShortRangeCheckCircuit::<pallas::Base, Lookup>::new(Value::known(element), num_bits);
+            MyShortRangeCheckCircuit::<pallas::Base, Lookup>::new(Value::known(element), num_bits);
         let prover = MockProver::<pallas::Base>::run(11, &circuit, vec![]).unwrap();
         assert_eq!(prover.verify(), *proof_result);
 

--- a/halo2_gadgets/src/utilities/lookup_range_check.rs
+++ b/halo2_gadgets/src/utilities/lookup_range_check.rs
@@ -105,7 +105,7 @@ pub trait LookupRangeCheck<F: PrimeFieldBits, const K: usize>: Eq + Copy + Debug
     ///
     /// This is only used in testing for now, since the Sinsemilla chip provides a pre-loaded table
     /// in the Orchard context.
-    fn load_only_range_check_table(&self, layouter: &mut impl Layouter<F>) -> Result<(), Error>;
+    fn load_range_check_table(&self, layouter: &mut impl Layouter<F>) -> Result<(), Error>;
 
     /// Constrain `x` to be a NUM_BITS word.
     ///
@@ -431,7 +431,7 @@ impl<F: PrimeFieldBits, const K: usize> LookupRangeCheck<F, K> for LookupRangeCh
     // Fill `table_idx` and `table_range_check_tag`.
     // This is only used in testing for now, since the Sinsemilla chip provides a pre-loaded table
     // in the Orchard context.
-    fn load_only_range_check_table(&self, layouter: &mut impl Layouter<F>) -> Result<(), Error> {
+    fn load_range_check_table(&self, layouter: &mut impl Layouter<F>) -> Result<(), Error> {
         layouter.assign_table(
             || "table_idx",
             |mut table| {
@@ -763,7 +763,7 @@ impl<F: PrimeFieldBits, const K: usize> LookupRangeCheck<F, K>
     // Fill `table_idx` and `table_range_check_tag`.
     // This is only used in testing for now, since the Sinsemilla chip provides a pre-loaded table
     // in the Orchard context.
-    fn load_only_range_check_table(&self, layouter: &mut impl Layouter<F>) -> Result<(), Error> {
+    fn load_range_check_table(&self, layouter: &mut impl Layouter<F>) -> Result<(), Error> {
         layouter.assign_table(
             || "table_idx",
             |mut table| {
@@ -901,7 +901,7 @@ mod tests {
             mut layouter: impl Layouter<F>,
         ) -> Result<(), Error> {
             // Load table_idx
-            config.load_only_range_check_table(&mut layouter)?;
+            config.load_range_check_table(&mut layouter)?;
 
             // Lookup constraining element to be no longer than num_words * K bits.
             let elements_and_expected_final_zs = [
@@ -1024,7 +1024,7 @@ mod tests {
             mut layouter: impl Layouter<F>,
         ) -> Result<(), Error> {
             // Load table_idx
-            config.load_only_range_check_table(&mut layouter)?;
+            config.load_range_check_table(&mut layouter)?;
 
             // Lookup constraining element to be no longer than num_bits.
             config.witness_short_check(

--- a/halo2_gadgets/src/utilities/lookup_range_check.rs
+++ b/halo2_gadgets/src/utilities/lookup_range_check.rs
@@ -10,9 +10,9 @@ use std::{convert::TryInto, fmt::Debug, marker::PhantomData};
 
 use ff::PrimeFieldBits;
 
+use crate::sinsemilla::{chip::generator_table::GeneratorTableConfig, primitives as sinsemilla};
 use pasta_curves::pallas;
-
-use crate::sinsemilla::primitives as sinsemilla;
+use sinsemilla::SINSEMILLA_S;
 
 use super::*;
 
@@ -96,12 +96,19 @@ pub trait LookupRangeCheck<F: PrimeFieldBits, const K: usize>: Eq + Copy + Debug
     /// Returns the table column that contains the range check tag.
     fn table_range_check_tag(&self) -> Option<TableColumn>;
 
+    /// Load the generator table into the circuit.
+    fn load(
+        &self,
+        generator_table_config: &GeneratorTableConfig,
+        layouter: &mut impl Layouter<pallas::Base>,
+    ) -> Result<(), Error>;
+
     #[cfg(test)]
     /// Fill `table_idx` and `table_range_check_tag`.
     ///
     /// This is only used in testing for now, since the Sinsemilla chip provides a pre-loaded table
     /// in the Orchard context.
-    fn load(&self, layouter: &mut impl Layouter<F>) -> Result<(), Error>;
+    fn load_only_range_check_table(&self, layouter: &mut impl Layouter<F>) -> Result<(), Error>;
 
     /// Constrain `x` to be a NUM_BITS word.
     ///
@@ -386,11 +393,52 @@ impl<F: PrimeFieldBits, const K: usize> LookupRangeCheck<F, K> for LookupRangeCh
         None
     }
 
+    /// Load the generator table into the circuit.
+    ///
+    /// | table_idx |     table_x    |     table_y    |
+    /// ------------------------------------------------
+    /// |     0     |    X(S\[0\])   |    Y(S\[0\])   |
+    /// |     1     |    X(S\[1\])   |    Y(S\[1\])   |
+    /// |    ...    |      ...       |       ...      |
+    /// |   2^10-1  | X(S\[2^10-1\]) | Y(S\[2^10-1\]) |
+    fn load(
+        &self,
+        generator_table_config: &GeneratorTableConfig,
+        layouter: &mut impl Layouter<pallas::Base>,
+    ) -> Result<(), Error> {
+        layouter.assign_table(
+            || "generator_table",
+            |mut table| {
+                for (index, (x, y)) in SINSEMILLA_S.iter().enumerate() {
+                    table.assign_cell(
+                        || "table_idx",
+                        generator_table_config.table_idx,
+                        index,
+                        || Value::known(pallas::Base::from(index as u64)),
+                    )?;
+                    table.assign_cell(
+                        || "table_x",
+                        generator_table_config.table_x,
+                        index,
+                        || Value::known(*x),
+                    )?;
+                    table.assign_cell(
+                        || "table_y",
+                        generator_table_config.table_y,
+                        index,
+                        || Value::known(*y),
+                    )?;
+                }
+                Ok(())
+            },
+        )
+    }
+
     #[cfg(test)]
     // Fill `table_idx` and `table_range_check_tag`.
     // This is only used in testing for now, since the Sinsemilla chip provides a pre-loaded table
     // in the Orchard context.
-    fn load(&self, layouter: &mut impl Layouter<F>) -> Result<(), Error> {
+    fn load_only_range_check_table(&self, layouter: &mut impl Layouter<F>) -> Result<(), Error> {
         layouter.assign_table(
             || "table_idx",
             |mut table| {
@@ -612,11 +660,121 @@ impl<F: PrimeFieldBits, const K: usize> LookupRangeCheck<F, K>
         Some(self.table_range_check_tag)
     }
 
+    /// Load the generator table into the circuit.
+    ///
+    /// | table_idx |     table_x    |     table_y    | table_range_check_tag |
+    /// -------------------------------------------------------------------
+    /// |     0     |    X(S\[0\])   |    Y(S\[0\])   |           0           |
+    /// |     1     |    X(S\[1\])   |    Y(S\[1\])   |           0           |
+    /// |    ...    |      ...       |       ...      |           0           |
+    /// |   2^10-1  | X(S\[2^10-1\]) | Y(S\[2^10-1\]) |           0           |
+    /// |     0     |    X(S\[0\])   |    Y(S\[0\])   |           4           |
+    /// |     1     |    X(S\[1\])   |    Y(S\[1\])   |           4           |
+    /// |    ...    |       ...      |       ...      |           4           |
+    /// |   2^4-1   | X(S\[2^4-1\])  | Y(S\[2^4-1\])  |           4           |
+    /// |     0     |    X(S\[0\])   |    Y(S\[0\])   |           5           |
+    /// |     1     |    X(S\[1\])   |    Y(S\[1\])   |           5           |
+    /// |    ...    |       ...      |       ...      |           5           |
+    /// |   2^5-1   | X(S\[2^5-1\])  | Y(S\[2^5-1\])  |           5           |
+    fn load(
+        &self,
+        generator_table_config: &GeneratorTableConfig,
+        layouter: &mut impl Layouter<pallas::Base>,
+    ) -> Result<(), Error> {
+        layouter.assign_table(
+            || "generator_table",
+            |mut table| {
+                for (index, (x, y)) in SINSEMILLA_S.iter().enumerate() {
+                    table.assign_cell(
+                        || "table_idx",
+                        generator_table_config.table_idx,
+                        index,
+                        || Value::known(pallas::Base::from(index as u64)),
+                    )?;
+                    table.assign_cell(
+                        || "table_x",
+                        generator_table_config.table_x,
+                        index,
+                        || Value::known(*x),
+                    )?;
+                    table.assign_cell(
+                        || "table_y",
+                        generator_table_config.table_y,
+                        index,
+                        || Value::known(*y),
+                    )?;
+
+                    table.assign_cell(
+                        || "table_range_check_tag",
+                        self.table_range_check_tag,
+                        index,
+                        || Value::known(pallas::Base::zero()),
+                    )?;
+                    if index < (1 << 4) {
+                        let new_index = index + (1 << sinsemilla::K);
+                        table.assign_cell(
+                            || "table_idx",
+                            generator_table_config.table_idx,
+                            new_index,
+                            || Value::known(pallas::Base::from(index as u64)),
+                        )?;
+                        table.assign_cell(
+                            || "table_x",
+                            generator_table_config.table_x,
+                            new_index,
+                            || Value::known(*x),
+                        )?;
+                        table.assign_cell(
+                            || "table_y",
+                            generator_table_config.table_y,
+                            new_index,
+                            || Value::known(*y),
+                        )?;
+                        table.assign_cell(
+                            || "table_range_check_tag",
+                            self.table_range_check_tag,
+                            new_index,
+                            || Value::known(pallas::Base::from(4_u64)),
+                        )?;
+                    }
+                    if index < (1 << 5) {
+                        let new_index = index + (1 << 10) + (1 << 4);
+                        table.assign_cell(
+                            || "table_idx",
+                            generator_table_config.table_idx,
+                            new_index,
+                            || Value::known(pallas::Base::from(index as u64)),
+                        )?;
+                        table.assign_cell(
+                            || "table_x",
+                            generator_table_config.table_x,
+                            new_index,
+                            || Value::known(*x),
+                        )?;
+                        table.assign_cell(
+                            || "table_y",
+                            generator_table_config.table_y,
+                            new_index,
+                            || Value::known(*y),
+                        )?;
+                        table.assign_cell(
+                            || "table_range_check_tag",
+                            self.table_range_check_tag,
+                            new_index,
+                            || Value::known(pallas::Base::from(5_u64)),
+                        )?;
+                    }
+                }
+                Ok(())
+            },
+        )
+    }
+
     #[cfg(test)]
     // Fill `table_idx` and `table_range_check_tag`.
     // This is only used in testing for now, since the Sinsemilla chip provides a pre-loaded table
     // in the Orchard context.
-    fn load(&self, layouter: &mut impl Layouter<F>) -> Result<(), Error> {
+    fn load_only_range_check_table(&self, layouter: &mut impl Layouter<F>) -> Result<(), Error> {
         layouter.assign_table(
             || "table_idx",
             |mut table| {
@@ -754,7 +912,7 @@ mod tests {
             mut layouter: impl Layouter<F>,
         ) -> Result<(), Error> {
             // Load table_idx
-            config.load(&mut layouter)?;
+            config.load_only_range_check_table(&mut layouter)?;
 
             // Lookup constraining element to be no longer than num_words * K bits.
             let elements_and_expected_final_zs = [
@@ -877,7 +1035,7 @@ mod tests {
             mut layouter: impl Layouter<F>,
         ) -> Result<(), Error> {
             // Load table_idx
-            config.load(&mut layouter)?;
+            config.load_only_range_check_table(&mut layouter)?;
 
             // Lookup constraining element to be no longer than num_bits.
             config.witness_short_check(

--- a/halo2_gadgets/src/utilities/lookup_range_check.rs
+++ b/halo2_gadgets/src/utilities/lookup_range_check.rs
@@ -93,9 +93,6 @@ pub trait LookupRangeCheck<F: PrimeFieldBits, const K: usize>: Eq + Copy + Debug
     where
         Self: Sized;
 
-    /// Returns the table column that contains the range check tag.
-    fn table_range_check_tag(&self) -> Option<TableColumn>;
-
     /// Load the generator table into the circuit.
     fn load(
         &self,
@@ -389,10 +386,6 @@ impl<F: PrimeFieldBits, const K: usize> LookupRangeCheck<F, K> for LookupRangeCh
         config
     }
 
-    fn table_range_check_tag(&self) -> Option<TableColumn> {
-        None
-    }
-
     /// Load the generator table into the circuit.
     ///
     /// | table_idx |     table_x    |     table_y    |
@@ -654,10 +647,6 @@ impl<F: PrimeFieldBits, const K: usize> LookupRangeCheck<F, K>
     ) -> Self {
         let table_range_check_tag = meta.lookup_table_column();
         Self::configure_with_tag(meta, running_sum, table_idx, table_range_check_tag)
-    }
-
-    fn table_range_check_tag(&self) -> Option<TableColumn> {
-        Some(self.table_range_check_tag)
     }
 
     /// Load the generator table into the circuit.

--- a/halo2_gadgets/src/utilities/lookup_range_check.rs
+++ b/halo2_gadgets/src/utilities/lookup_range_check.rs
@@ -58,7 +58,7 @@ impl<F: PrimeFieldBits> RangeConstrained<F, AssignedCell<F, F>> {
     }
 }
 
-/// Configuration that provides methods for a 10-bit lookup range check.
+/// Configuration that provides methods for a lookup range check.
 #[derive(Eq, PartialEq, Debug, Clone, Copy)]
 pub struct LookupRangeCheckConfig<F: PrimeFieldBits, const K: usize> {
     q_lookup: Selector,
@@ -715,14 +715,14 @@ mod tests {
     use std::{convert::TryInto, marker::PhantomData};
 
     #[derive(Clone, Copy)]
-    struct MyLookupCircuit<F: PrimeFieldBits, Lookup: LookupRangeCheck<F, K>> {
+    struct LookupCircuit<F: PrimeFieldBits, Lookup: LookupRangeCheck<F, K>> {
         num_words: usize,
         _marker: PhantomData<(F, Lookup)>,
     }
 
-    impl<F: PrimeFieldBits, Lookup: LookupRangeCheck<F, K>> MyLookupCircuit<F, Lookup> {
+    impl<F: PrimeFieldBits, Lookup: LookupRangeCheck<F, K>> LookupCircuit<F, Lookup> {
         fn new(num_words: usize) -> Self {
-            MyLookupCircuit {
+            LookupCircuit {
                 num_words,
                 _marker: PhantomData,
             }
@@ -730,13 +730,13 @@ mod tests {
     }
 
     impl<F: PrimeFieldBits, Lookup: LookupRangeCheck<F, K> + std::clone::Clone> Circuit<F>
-        for MyLookupCircuit<F, Lookup>
+        for LookupCircuit<F, Lookup>
     {
         type Config = Lookup;
         type FloorPlanner = SimpleFloorPlanner;
 
         fn without_witnesses(&self) -> Self {
-            MyLookupCircuit::new(self.num_words)
+            LookupCircuit::new(self.num_words)
         }
 
         fn configure(meta: &mut ConstraintSystem<F>) -> Self::Config {
@@ -811,40 +811,40 @@ mod tests {
 
     #[test]
     fn lookup_range_check() {
-        let circuit = MyLookupCircuit::<pallas::Base, PallasLookupRangeCheckConfig>::new(6);
+        let circuit = LookupCircuit::<pallas::Base, PallasLookupRangeCheckConfig>::new(6);
         let prover = MockProver::<pallas::Base>::run(11, &circuit, vec![]).unwrap();
         assert_eq!(prover.verify(), Ok(()));
     }
 
     #[test]
     fn test_lookup_range_check_against_stored_circuit() {
-        let circuit = MyLookupCircuit::<pallas::Base, PallasLookupRangeCheckConfig>::new(6);
+        let circuit = LookupCircuit::<pallas::Base, PallasLookupRangeCheckConfig>::new(6);
         test_against_stored_circuit(circuit, "lookup_range_check", 1888);
     }
 
     #[test]
     fn lookup_range_check_4_5b() {
-        let circuit = MyLookupCircuit::<pallas::Base, PallasLookupRangeCheck4_5BConfig>::new(6);
+        let circuit = LookupCircuit::<pallas::Base, PallasLookupRangeCheck4_5BConfig>::new(6);
         let prover = MockProver::<pallas::Base>::run(11, &circuit, vec![]).unwrap();
         assert_eq!(prover.verify(), Ok(()));
     }
 
     #[test]
     fn test_lookup_range_check_against_stored_circuit_4_5b() {
-        let circuit = MyLookupCircuit::<pallas::Base, PallasLookupRangeCheck4_5BConfig>::new(6);
+        let circuit = LookupCircuit::<pallas::Base, PallasLookupRangeCheck4_5BConfig>::new(6);
         test_against_stored_circuit(circuit, "lookup_range_check_4_5b", 2048);
     }
 
     #[derive(Clone, Copy)]
-    struct MyShortRangeCheckCircuit<F: PrimeFieldBits, Lookup: LookupRangeCheck<F, K>> {
+    struct ShortRangeCheckCircuit<F: PrimeFieldBits, Lookup: LookupRangeCheck<F, K>> {
         element: Value<F>,
         num_bits: usize,
         _lookup_marker: PhantomData<Lookup>,
     }
 
-    impl<F: PrimeFieldBits, Lookup: LookupRangeCheck<F, K>> MyShortRangeCheckCircuit<F, Lookup> {
+    impl<F: PrimeFieldBits, Lookup: LookupRangeCheck<F, K>> ShortRangeCheckCircuit<F, Lookup> {
         fn new(element: Value<F>, num_bits: usize) -> Self {
-            MyShortRangeCheckCircuit {
+            ShortRangeCheckCircuit {
                 element,
                 num_bits,
                 _lookup_marker: PhantomData,
@@ -853,13 +853,13 @@ mod tests {
     }
 
     impl<F: PrimeFieldBits, Lookup: LookupRangeCheck<F, K> + std::clone::Clone> Circuit<F>
-        for MyShortRangeCheckCircuit<F, Lookup>
+        for ShortRangeCheckCircuit<F, Lookup>
     {
         type Config = Lookup;
         type FloorPlanner = SimpleFloorPlanner;
 
         fn without_witnesses(&self) -> Self {
-            MyShortRangeCheckCircuit::new(Value::unknown(), self.num_bits)
+            ShortRangeCheckCircuit::new(Value::unknown(), self.num_bits)
         }
 
         fn configure(meta: &mut ConstraintSystem<F>) -> Self::Config {
@@ -898,7 +898,7 @@ mod tests {
         expected_proof_size: usize,
     ) {
         let circuit =
-            MyShortRangeCheckCircuit::<pallas::Base, Lookup>::new(Value::known(element), num_bits);
+            ShortRangeCheckCircuit::<pallas::Base, Lookup>::new(Value::known(element), num_bits);
         let prover = MockProver::<pallas::Base>::run(11, &circuit, vec![]).unwrap();
         assert_eq!(prover.verify(), *proof_result);
 


### PR DESCRIPTION
- Move lookup table load function into LookupRangeCheck trait (and remove table_range_check_tag function which is no longer used)
- Move some imports to reduce the diff with the main branch
- Standardize test circuit names
- Reduce visibility of some functions
- Update changelog file
