### PR TITLE
Add NonIdentityPoint::new_from_constant

### DIFF
--- a/halo2_gadgets/src/ecc.rs
+++ b/halo2_gadgets/src/ecc.rs
@@ -77,6 +77,14 @@ pub trait EccInstructions<C: CurveAffine>:
         value: Value<C>,
     ) -> Result<Self::NonIdentityPoint, Error>;
 
+    /// Witnesses the given constant point with both coordinates pinned via fixed columns.
+    /// Returns an error if the point is the identity.
+    fn witness_point_non_id_from_constant(
+        &self,
+        layouter: &mut impl Layouter<C::Base>,
+        value: C,
+    ) -> Result<Self::NonIdentityPoint, Error>;
+
     /// Witnesses a full-width scalar to be used in variable-base multiplication.
     fn witness_scalar_var(
         &self,
@@ -280,13 +288,24 @@ pub struct NonIdentityPoint<C: CurveAffine, EccChip: EccInstructions<C>> {
 }
 
 impl<C: CurveAffine, EccChip: EccInstructions<C>> NonIdentityPoint<C, EccChip> {
-    /// Constructs a new point with the given value.
+    /// Witnesses the given point with only on-curve / non-identity constraints.
+    /// For known-constant points use [`NonIdentityPoint::new_from_constant`].
     pub fn new(
         chip: EccChip,
         mut layouter: impl Layouter<C::Base>,
         value: Value<C>,
     ) -> Result<Self, Error> {
         let point = chip.witness_point_non_id(&mut layouter, value);
+        point.map(|inner| NonIdentityPoint { chip, inner })
+    }
+
+    /// Witnesses the given constant point with both coordinates pinned via fixed columns.
+    pub fn new_from_constant(
+        chip: EccChip,
+        mut layouter: impl Layouter<C::Base>,
+        value: C,
+    ) -> Result<Self, Error> {
+        let point = chip.witness_point_non_id_from_constant(&mut layouter, value);
         point.map(|inner| NonIdentityPoint { chip, inner })
     }
 

--- a/halo2_gadgets/src/ecc/chip.rs
+++ b/halo2_gadgets/src/ecc/chip.rs
@@ -492,6 +492,18 @@ where
         )
     }
 
+    fn witness_point_non_id_from_constant(
+        &self,
+        layouter: &mut impl Layouter<pallas::Base>,
+        value: pallas::Affine,
+    ) -> Result<Self::NonIdentityPoint, Error> {
+        let config = self.config().witness_point;
+        layouter.assign_region(
+            || "witness constant non-identity point",
+            |mut region| config.constant_point_non_id(value, 0, &mut region),
+        )
+    }
+
     fn witness_scalar_var(
         &self,
         _layouter: &mut impl Layouter<pallas::Base>,

--- a/halo2_gadgets/src/ecc/chip/witness_point.rs
+++ b/halo2_gadgets/src/ecc/chip/witness_point.rs
@@ -184,6 +184,30 @@ impl Config {
         self.assign_xy(value, offset, region)
             .map(|(x, y)| NonIdentityEccPoint::from_coordinates_unchecked(x, y))
     }
+
+    /// Assigns a constant non-identity point with both coordinates pinned via fixed columns.
+    pub(super) fn constant_point_non_id(
+        &self,
+        value: pallas::Affine,
+        offset: usize,
+        region: &mut Region<'_, pallas::Base>,
+    ) -> Result<NonIdentityEccPoint, Error> {
+        // Enable `q_point_non_id` selector
+        self.q_point_non_id.enable(region, offset)?;
+
+        // Return an error if the point is the identity.
+        if value == pallas::Affine::identity() {
+            return Err(Error::Synthesis);
+        }
+
+        let value = {
+            let value = value.coordinates().unwrap();
+            (value.x().into(), value.y().into())
+        };
+
+        self.assign_xy_from_constant(value, offset, region)
+            .map(|(x, y)| NonIdentityEccPoint::from_coordinates_unchecked(x, y))
+    }
 }
 
 #[cfg(test)]
@@ -202,9 +226,17 @@ pub mod tests {
     ) {
         // Witnessing the identity should return an error.
         NonIdentityPoint::new(
-            chip,
+            chip.clone(),
             layouter.namespace(|| "witness identity"),
             Value::known(pallas::Affine::identity()),
+        )
+        .expect_err("witnessing 𝒪 should return an error");
+
+        // Witnessing the identity from a constant should return an error.
+        NonIdentityPoint::new_from_constant(
+            chip,
+            layouter.namespace(|| "witness identity"),
+            pallas::Affine::identity(),
         )
         .expect_err("witnessing 𝒪 should return an error");
     }


### PR DESCRIPTION
This PR adds `NonIdentityPoint::new_from_constant` to enable creating non-identity points that are properly pinned to constants, which is required by the Orchard ZSA circuit ([Orchard PR](https://github.com/QED-it/orchard/pull/246)).

More precisely, in the Orchard ZSA circuit, `q_init_zec` / `q_init_zsa` must be constrained to fixed constants, as they define the initial point `Q` of the Sinsemilla hash. If constructed via `NonIdentityPoint::new`, they remain unconstrained witnesses, allowing a prover to inject an arbitrary on-curve point and break commitment soundness.